### PR TITLE
[Feat] 디자인 변경에 맞게 로그인화면의 UI를 수정했습니다.

### DIFF
--- a/Popcorn-iOS/Source/Presentation/Login/LoginScene/Controller/LoginViewController.swift
+++ b/Popcorn-iOS/Source/Presentation/Login/LoginScene/Controller/LoginViewController.swift
@@ -57,13 +57,13 @@ class LoginViewController: UIViewController {
 // MARK: - TextField Delegate Protocol
 extension LoginViewController: UITextFieldDelegate {
     private func setupTextField() {
-        loginView.emailTextField.delegate = self
+        loginView.idTextField.delegate = self
         loginView.passwordTextField.delegate = self
     }
 
     func textFieldDidBeginEditing(_ textField: UITextField) {
-        if textField == loginView.emailTextField {
-            loginView.emailTextField.backgroundColor = #colorLiteral(red: 0.921431005, green: 0.9214526415, blue: 0.9214410186, alpha: 1)
+        if textField == loginView.idTextField {
+            loginView.idTextField.backgroundColor = #colorLiteral(red: 0.921431005, green: 0.9214526415, blue: 0.9214410186, alpha: 1)
         }
         if textField == loginView.passwordTextField {
             loginView.passwordTextField.backgroundColor = #colorLiteral(red: 0.921431005, green: 0.9214526415, blue: 0.9214410186, alpha: 1)
@@ -71,8 +71,8 @@ extension LoginViewController: UITextFieldDelegate {
     }
 
     func textFieldDidEndEditing(_ textField: UITextField, reason: UITextField.DidEndEditingReason) {
-        if textField == loginView.emailTextField {
-            loginView.emailTextField.backgroundColor = #colorLiteral(red: 0.969, green: 0.973, blue: 0.976, alpha: 1)
+        if textField == loginView.idTextField {
+            loginView.idTextField.backgroundColor = #colorLiteral(red: 0.969, green: 0.973, blue: 0.976, alpha: 1)
         }
         if textField == loginView.passwordTextField {
             loginView.passwordTextField.backgroundColor = #colorLiteral(red: 0.969, green: 0.973, blue: 0.976, alpha: 1)
@@ -80,13 +80,13 @@ extension LoginViewController: UITextFieldDelegate {
     }
 
     func textFieldShouldReturn(_ textField: UITextField) -> Bool {
-        if textField == loginView.emailTextField {
-            guard let emailText = loginView.emailTextField.text, !emailText.isEmpty else { return false }
+        if textField == loginView.idTextField {
+            guard let idText = loginView.idTextField.text, !idText.isEmpty else { return false }
             loginView.passwordTextField.becomeFirstResponder()
             return true
         }
         if textField == loginView.passwordTextField {
-            guard let emailText = loginView.emailTextField.text, !emailText.isEmpty,
+            guard let idText = loginView.idTextField.text, !idText.isEmpty,
                   let passwordText = loginView.passwordTextField.text, !passwordText.isEmpty else { return false }
             loginView.passwordTextField.resignFirstResponder()
             loginView.loginButton.sendActions(for: .touchUpInside)

--- a/Popcorn-iOS/Source/Presentation/Login/LoginScene/View/LoginView.swift
+++ b/Popcorn-iOS/Source/Presentation/Login/LoginScene/View/LoginView.swift
@@ -57,8 +57,6 @@ final class LoginView: UIView {
         button.titleLabel?.font = .systemFont(ofSize: 14)
         button.backgroundColor = .clear
         button.titleLabel?.textAlignment = .center
-        button.titleLabel?.adjustsFontSizeToFitWidth = true
-        button.titleLabel?.minimumScaleFactor = 1.0
         button.titleLabel?.numberOfLines = 1
         return button
     }()
@@ -78,8 +76,6 @@ final class LoginView: UIView {
         button.titleLabel?.font = .systemFont(ofSize: 14)
         button.backgroundColor = .clear
         button.titleLabel?.textAlignment = .center
-        button.titleLabel?.adjustsFontSizeToFitWidth = true
-        button.titleLabel?.minimumScaleFactor = 1.0
         button.titleLabel?.numberOfLines = 1
         return button
     }()

--- a/Popcorn-iOS/Source/Presentation/Login/LoginScene/View/LoginView.swift
+++ b/Popcorn-iOS/Source/Presentation/Login/LoginScene/View/LoginView.swift
@@ -16,8 +16,8 @@ final class LoginView: UIView {
         return imageView
     }()
 
-    let emailTextField = LoginTextField(
-        placeholder: "이메일",
+    let idTextField = LoginTextField(
+        placeholder: "아이디",
         keyboardType: .emailAddress
     )
 
@@ -38,11 +38,10 @@ final class LoginView: UIView {
         return button
     }()
 
-    lazy var emailPasswordLoginStackView: UIStackView = {
+    lazy var idPasswordStackView: UIStackView = {
         let stackView = UIStackView(arrangedSubviews: [
-            emailTextField,
-            passwordTextField,
-            loginButton
+            idTextField,
+            passwordTextField
         ])
         stackView.axis = .vertical
         stackView.spacing = 20
@@ -53,7 +52,7 @@ final class LoginView: UIView {
 
     let findButton: UIButton = {
         let button = UIButton()
-        button.setTitle("아이디 /비밀번호 찾기", for: .normal)
+        button.setTitle("아이디 / 비밀번호 찾기", for: .normal)
         button.setTitleColor(.black, for: .normal)
         button.titleLabel?.font = .systemFont(ofSize: 14)
         button.backgroundColor = .clear
@@ -195,7 +194,7 @@ extension LoginView {
 // MARK: - Configure TextFields
 extension LoginView {
     func configureTextFields() {
-        emailTextField.addTarget(self, action: #selector(textFieldEditingChanged(_:)), for: .editingChanged)
+        idTextField.addTarget(self, action: #selector(textFieldEditingChanged(_:)), for: .editingChanged)
         passwordTextField.addTarget(self, action: #selector(textFieldEditingChanged(_:)), for: .editingChanged)
     }
 
@@ -209,7 +208,8 @@ extension LoginView {
     private func configureSubviews() {
         [
             popcornImageView,
-            emailPasswordLoginStackView,
+            idPasswordStackView,
+            loginButton,
             findSignUpStackView,
             separateStackView,
             socialLoginStackView
@@ -225,22 +225,18 @@ extension LoginView {
             popcornImageView.centerXAnchor.constraint(equalTo: safeAreaLayoutGuide.centerXAnchor),
             popcornImageView.topAnchor.constraint(equalTo: safeAreaLayoutGuide.topAnchor, constant: 81),
 
-            emailPasswordLoginStackView.leadingAnchor.constraint(
-                equalTo: safeAreaLayoutGuide.leadingAnchor,
-                constant: 32
-            ),
-            emailPasswordLoginStackView.trailingAnchor.constraint(
-                equalTo: safeAreaLayoutGuide.trailingAnchor,
-                constant: -32
-            ),
-            emailPasswordLoginStackView.topAnchor.constraint(
-                equalTo: popcornImageView.bottomAnchor,
-                constant: 56
-            ),
+            idPasswordStackView.leadingAnchor.constraint(equalTo: safeAreaLayoutGuide.leadingAnchor, constant: 32),
+            idPasswordStackView.trailingAnchor.constraint(equalTo: safeAreaLayoutGuide.trailingAnchor, constant: -32),
+            idPasswordStackView.topAnchor.constraint(equalTo: popcornImageView.bottomAnchor, constant: 56),
 
-            findSignUpStackView.leadingAnchor.constraint(equalTo: safeAreaLayoutGuide.leadingAnchor, constant: 96),
-            findSignUpStackView.trailingAnchor.constraint(equalTo: safeAreaLayoutGuide.trailingAnchor, constant: -96),
-            findSignUpStackView.topAnchor.constraint(equalTo: emailPasswordLoginStackView.bottomAnchor, constant: 28),
+            loginButton.leadingAnchor.constraint(equalTo: safeAreaLayoutGuide.leadingAnchor, constant: 32),
+            loginButton.trailingAnchor.constraint(equalTo: safeAreaLayoutGuide.trailingAnchor, constant: -32),
+            loginButton.topAnchor.constraint(equalTo: idPasswordStackView.bottomAnchor, constant: 27),
+            loginButton.heightAnchor.constraint(equalTo: idTextField.heightAnchor, constant: 3),
+
+            findSignUpStackView.leadingAnchor.constraint(equalTo: safeAreaLayoutGuide.leadingAnchor, constant: 95),
+            findSignUpStackView.trailingAnchor.constraint(equalTo: safeAreaLayoutGuide.trailingAnchor, constant: -95),
+            findSignUpStackView.topAnchor.constraint(equalTo: loginButton.bottomAnchor, constant: 28),
 
             separateStackView.leadingAnchor.constraint(equalTo: safeAreaLayoutGuide.leadingAnchor, constant: 26),
             separateStackView.centerXAnchor.constraint(equalTo: safeAreaLayoutGuide.centerXAnchor),
@@ -263,7 +259,7 @@ extension LoginView {
             }
         }
         guard
-            let email = emailTextField.text, !email.isEmpty,
+            let id = idTextField.text, !id.isEmpty,
             let password = passwordTextField.text, !password.isEmpty else {
             loginButton.backgroundColor = .lightGray
             loginButton.isEnabled = false


### PR DESCRIPTION
# 배경

![image](https://github.com/user-attachments/assets/e662de0e-977f-41a7-a376-8b1bbf78ad90)
#9 #62 

# 작업 내용

<img width="532" alt="스크린샷 2024-11-21 00 47 58" src="https://github.com/user-attachments/assets/39be26b2-b207-4092-96e8-dcd547e9901e">

## UI 및 코드 수정
- 디자인의 변경사항에 맞게 이메일에 해당하는 텍스트를 아이디로 변경했습니다.
- 디자인에 맞게 텍스트필드와 로그인버튼의 크기를 다르게 설정했습니다.
- 아이디 / 비밀번호 찾기와 회원가입 버튼의 불필요한 코드 삭제가 #62 에 반영되지 않아 수정했습니다.

# 테스트 방법
- 프리뷰 코드를 사용해서 UI를 확인할 수 있습니다.

# 리뷰 노트
- 소셜로그인을 제외한 UI는 최종코드에 가깝습니다.
- 추후 버튼에서 `Configuration`기능을 사용하여 리팩토링 과정이 있을거 같습니다.
