### PR TITLE
[Feat] 디자인 변경에 맞게 회원가입 화면 1의 UI를 수정했습니다.

### DIFF
--- a/Popcorn-iOS/Source/Presentation/SignUp/Common/View/SignUpFieldStackView.swift
+++ b/Popcorn-iOS/Source/Presentation/SignUp/Common/View/SignUpFieldStackView.swift
@@ -10,6 +10,9 @@ import UIKit
 final class SignUpFieldStackView: UIStackView {
     private let signUpTextField: SignUpTextField
     private let signUpLabel: SignUpLabel
+    var textFieldReference: SignUpTextField {
+        return signUpTextField
+    }
 
     init(
         labelText: String,
@@ -26,10 +29,6 @@ final class SignUpFieldStackView: UIStackView {
 
     required init(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
-    }
-
-    var textFieldReference: SignUpTextField {
-        return signUpTextField
     }
 }
 

--- a/Popcorn-iOS/Source/Presentation/SignUp/Common/View/SignUpTextField.swift
+++ b/Popcorn-iOS/Source/Presentation/SignUp/Common/View/SignUpTextField.swift
@@ -55,7 +55,7 @@ extension SignUpTextField {
         textAlignment = .left
         clipsToBounds = true
         layer.cornerRadius = 10
-        layer.borderColor = #colorLiteral(red: 0.855, green: 0.855, blue: 0.855, alpha: 1)
+        layer.borderColor = UIColor(resource: .popcornGray2).cgColor
         layer.borderWidth = 1
     }
 }

--- a/Popcorn-iOS/Source/Presentation/SignUp/SignUpScene/View/SignUpFirstView.swift
+++ b/Popcorn-iOS/Source/Presentation/SignUp/SignUpScene/View/SignUpFirstView.swift
@@ -39,8 +39,6 @@ class SignUpFirstView: UIView {
         var config = UIButton.Configuration.filled()
         config.baseBackgroundColor = UIColor(resource: .popcornOrange)
         config.background.cornerRadius = 10
-        config.background.strokeWidth = 1
-        config.background.strokeColor = #colorLiteral(red: 0.855, green: 0.855, blue: 0.855, alpha: 1)
         config.attributedTitle = AttributedString(
             "인증요청",
             attributes: AttributeContainer([


### PR DESCRIPTION
# 배경

<img width="896" alt="스크린샷 2024-11-25 23 22 32" src="https://github.com/user-attachments/assets/8b298945-e724-48e4-8807-628724c6184f">


# 작업 내용

#68 에서
- 텍스트필드의 `border` 색상 변경
- `인증요청` 버튼의 `border` 삭제

# 테스트 방법

```swift
func scene(
        _ scene: UIScene,
        willConnectTo session: UISceneSession,
        options connectionOptions: UIScene.ConnectionOptions
    ) {
        guard let windowScene = (scene as? UIWindowScene) else { return }

        window = UIWindow(windowScene: windowScene)
        let loginViewController = LoginViewController()
        let navigationController = UINavigationController(rootViewController: loginViewController)
        window?.rootViewController = navigationController
        window?.makeKeyAndVisible()
    }
```
SceneDelegate 파일의 첫 번째 함수를 변경하면 확인할 수 있습니다.

# 리뷰 노트
- 프로퍼티의 선언부를 상단으로 올리는 커밋이 있었습니다.
- 나머지 코드의 내용은 #68 과 같습니다!