### PR TITLE
[Feat] 카카오톡 소셜로그인을 구현하였습니다.

### DIFF
--- a/Popcorn-iOS.xcodeproj/project.pbxproj
+++ b/Popcorn-iOS.xcodeproj/project.pbxproj
@@ -33,6 +33,9 @@
 		56CD3A722CEB83CF00BAC02D /* MainSceneViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56CD3A702CEB83CF00BAC02D /* MainSceneViewModel.swift */; };
 		56CD3A7B2CEB858100BAC02D /* PickOrInterestCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56CD3A7A2CEB858100BAC02D /* PickOrInterestCell.swift */; };
 		56CD3A7D2CEC31B000BAC02D /* UIView+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56CD3A7C2CEC314E00BAC02D /* UIView+.swift */; };
+		BC29A50E2D2EA5DF0059A5C5 /* KakaoSDKAuth in Frameworks */ = {isa = PBXBuildFile; productRef = BC29A50D2D2EA5DE0059A5C5 /* KakaoSDKAuth */; };
+		BC29A5102D2EA5DF0059A5C5 /* KakaoSDKCommon in Frameworks */ = {isa = PBXBuildFile; productRef = BC29A50F2D2EA5DF0059A5C5 /* KakaoSDKCommon */; };
+		BC29A5122D2EA5DF0059A5C5 /* KakaoSDKUser in Frameworks */ = {isa = PBXBuildFile; productRef = BC29A5112D2EA5DF0059A5C5 /* KakaoSDKUser */; };
 		BC2D11622CEC5DF60030F4E0 /* LoginView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC2D11612CEC5DF60030F4E0 /* LoginView.swift */; };
 		BC3201AB2D2CFC6900B73A14 /* ProfileImageCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC3201AA2D2CFC6900B73A14 /* ProfileImageCell.swift */; };
 		BC3201AE2D2D66DA00B73A14 /* ProfileImageColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC3201AD2D2D66DA00B73A14 /* ProfileImageColor.swift */; };
@@ -150,6 +153,9 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				BC29A5102D2EA5DF0059A5C5 /* KakaoSDKCommon in Frameworks */,
+				BC29A50E2D2EA5DF0059A5C5 /* KakaoSDKAuth in Frameworks */,
+				BC29A5122D2EA5DF0059A5C5 /* KakaoSDKUser in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -559,6 +565,9 @@
 			);
 			name = "Popcorn-iOS";
 			packageProductDependencies = (
+				BC29A50D2D2EA5DE0059A5C5 /* KakaoSDKAuth */,
+				BC29A50F2D2EA5DF0059A5C5 /* KakaoSDKCommon */,
+				BC29A5112D2EA5DF0059A5C5 /* KakaoSDKUser */,
 			);
 			productName = "Popcorn-iOS";
 			productReference = 56537B732CE0F5100092A292 /* Popcorn-iOS.app */;
@@ -617,6 +626,7 @@
 			minimizedProjectReferenceProxies = 1;
 			packageReferences = (
 				56AA6C032CE36EA8001952C2 /* XCRemoteSwiftPackageReference "SwiftLintPlugins" */,
+				BC29A50C2D2EA5DE0059A5C5 /* XCRemoteSwiftPackageReference "kakao-ios-sdk" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 56537B742CE0F5100092A292 /* Products */;
@@ -1017,7 +1027,33 @@
 				minimumVersion = 0.57.0;
 			};
 		};
+		BC29A50C2D2EA5DE0059A5C5 /* XCRemoteSwiftPackageReference "kakao-ios-sdk" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/kakao/kakao-ios-sdk";
+			requirement = {
+				branch = master;
+				kind = branch;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		BC29A50D2D2EA5DE0059A5C5 /* KakaoSDKAuth */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = BC29A50C2D2EA5DE0059A5C5 /* XCRemoteSwiftPackageReference "kakao-ios-sdk" */;
+			productName = KakaoSDKAuth;
+		};
+		BC29A50F2D2EA5DF0059A5C5 /* KakaoSDKCommon */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = BC29A50C2D2EA5DE0059A5C5 /* XCRemoteSwiftPackageReference "kakao-ios-sdk" */;
+			productName = KakaoSDKCommon;
+		};
+		BC29A5112D2EA5DF0059A5C5 /* KakaoSDKUser */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = BC29A50C2D2EA5DE0059A5C5 /* XCRemoteSwiftPackageReference "kakao-ios-sdk" */;
+			productName = KakaoSDKUser;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = 56537B6B2CE0F5100092A292 /* Project object */;
 }

--- a/Popcorn-iOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Popcorn-iOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,6 +1,24 @@
 {
-  "originHash" : "1fa961aa1dc717cea452f3389668f0f99a254f07e4eb11d190768a53798f744f",
+  "originHash" : "306c037219c364bcdf68ad8e185a269d88bafd09a49ade3113a080dbfe6821ae",
   "pins" : [
+    {
+      "identity" : "alamofire",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Alamofire/Alamofire.git",
+      "state" : {
+        "revision" : "513364f870f6bfc468f9d2ff0a95caccc10044c5",
+        "version" : "5.10.2"
+      }
+    },
+    {
+      "identity" : "kakao-ios-sdk",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/kakao/kakao-ios-sdk",
+      "state" : {
+        "branch" : "master",
+        "revision" : "ab4309c1950550add307046ad1e08024c7514603"
+      }
+    },
     {
       "identity" : "swiftlintplugins",
       "kind" : "remoteSourceControl",

--- a/Popcorn-iOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Popcorn-iOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "306c037219c364bcdf68ad8e185a269d88bafd09a49ade3113a080dbfe6821ae",
+  "originHash" : "4f5663505ab61141441b1775457928b207b9337669bfcad3d71570f6851ea604",
   "pins" : [
     {
       "identity" : "alamofire",

--- a/Popcorn-iOS/Resource/Info.plist
+++ b/Popcorn-iOS/Resource/Info.plist
@@ -2,6 +2,23 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>kakaoe8f4e07ad12752bb2e95ff40160ad6b0</string>
+			</array>
+		</dict>
+	</array>
+	<key>LSApplicationQueriesSchemes</key>
+	<array>
+		<string>kakaokompassauth</string>
+		<string>kakaolink</string>
+		<string>kakaoplus</string>
+	</array>
 	<key>UIAppFonts</key>
 	<array>
 		<string>RobotoFlex-VariableFont.ttf</string>

--- a/Popcorn-iOS/Source/Application/AppDelegate.swift
+++ b/Popcorn-iOS/Source/Application/AppDelegate.swift
@@ -5,8 +5,8 @@
 //  Created by 제민우 on 11/10/24.
 //
 
-import UIKit
 import KakaoSDKCommon
+import UIKit
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {

--- a/Popcorn-iOS/Source/Application/AppDelegate.swift
+++ b/Popcorn-iOS/Source/Application/AppDelegate.swift
@@ -6,6 +6,7 @@
 //
 
 import UIKit
+import KakaoSDKCommon
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
@@ -14,6 +15,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         _ application: UIApplication,
         didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
     ) -> Bool {
+        KakaoSDK.initSDK(appKey: "e8f4e07ad12752bb2e95ff40160ad6b0")
         return true
     }
 

--- a/Popcorn-iOS/Source/Application/SceneDelegate.swift
+++ b/Popcorn-iOS/Source/Application/SceneDelegate.swift
@@ -21,6 +21,8 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         window = UIWindow(windowScene: windowScene)
         window?.rootViewController = ViewController()
         window?.makeKeyAndVisible()
+    }
+
     func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {
         if let url = URLContexts.first?.url {
             if AuthApi.isKakaoTalkLoginUrl(url) {

--- a/Popcorn-iOS/Source/Application/SceneDelegate.swift
+++ b/Popcorn-iOS/Source/Application/SceneDelegate.swift
@@ -5,6 +5,7 @@
 //  Created by 제민우 on 11/10/24.
 //
 
+import KakaoSDKAuth
 import UIKit
 
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
@@ -20,6 +21,12 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         window = UIWindow(windowScene: windowScene)
         window?.rootViewController = ViewController()
         window?.makeKeyAndVisible()
+    func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {
+        if let url = URLContexts.first?.url {
+            if AuthApi.isKakaoTalkLoginUrl(url) {
+                _ = AuthController.handleOpenUrl(url: url)
+            }
+        }
     }
 
     func sceneDidDisconnect(_ scene: UIScene) {

--- a/Popcorn-iOS/Source/Presentation/Login/LoginScene/Controller/LoginViewController.swift
+++ b/Popcorn-iOS/Source/Presentation/Login/LoginScene/Controller/LoginViewController.swift
@@ -5,6 +5,7 @@
 //  Created by 김성훈 on 11/19/24.
 //
 
+import KakaoSDKUser
 import UIKit
 
 class LoginViewController: UIViewController {
@@ -16,8 +17,8 @@ class LoginViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        setupTextField()
         setupAddTarget()
+        setupTextField()
     }
 
     private func setupAddTarget() {
@@ -49,7 +50,11 @@ class LoginViewController: UIViewController {
     }
 
     @objc private func kakaoButtonTapped() {
-
+        if UserApi.isKakaoTalkLoginAvailable() {
+            loginWithApp()
+        } else {
+            loginWithWeb()
+        }
     }
 
     @objc private func googleButtonTapped() {
@@ -57,6 +62,52 @@ class LoginViewController: UIViewController {
     }
 
     @objc private func appleButtonTapped() {
+
+    }
+}
+
+// MARK: - Kakao Social Login SubFunction
+extension LoginViewController {
+    func loginWithApp() {
+        UserApi.shared.loginWithKakaoTalk { (oauthToken, error) in
+            if let error = error {
+                print(error)
+            } else {
+                self.fetchUserInfo()
+                self.sendTokenToServer()
+            }
+        }
+    }
+
+    func loginWithWeb() {
+        UserApi.shared.loginWithKakaoAccount { (oauthToken, error) in
+            if let error = error {
+                print(error)
+            } else {
+                self.fetchUserInfo()
+                self.sendTokenToServer()
+            }
+        }
+    }
+
+    private func fetchUserInfo() {
+        UserApi.shared.me { [weak self] (user, error) in
+            if let error = error {
+                print(error)
+            } else {
+                guard let nickname = user?.kakaoAccount?.profile?.nickname else { return }
+                self?.presentToSignUpSecondViewController(with: nickname)
+            }
+        }
+    }
+
+    func presentToSignUpSecondViewController(with nickname: String) {
+        let signUpSecondViewController = SignUpSecondViewController()
+        signUpSecondViewController.signUpSecondView.nickNameTextField.text = nickname
+        self.navigationController?.pushViewController(signUpSecondViewController, animated: true)
+    }
+    
+    private func sendTokenToServer() {
 
     }
 }

--- a/Popcorn-iOS/Source/Presentation/Login/LoginScene/View/LoginView.swift
+++ b/Popcorn-iOS/Source/Presentation/Login/LoginScene/View/LoginView.swift
@@ -229,25 +229,11 @@ final class LoginView: UIView {
         return stackView
     }()
 
-    private lazy var socialLoginStackView: UIStackView = {
-        let stackView = UIStackView(arrangedSubviews: [
-            socialLoginSeparateStackView,
-            socialLoginButtonStackView
-        ])
-        stackView.axis = .vertical
-        let screenHeight = UIScreen.main.bounds.height
-        let size = screenHeight * 26/852
-        stackView.spacing = size
-        stackView.alignment = .center
-        stackView.distribution = .fillProportionally
-        return stackView
-    }()
-
     private lazy var entireStackView: UIStackView = {
         let stackView = UIStackView(arrangedSubviews: [
             popcornImageView,
             loginFindSignUpContentStackView,
-            socialLoginStackView
+            socialLoginSeparateStackView
         ])
         stackView.axis = .vertical
         let screenHeight = UIScreen.main.bounds.height
@@ -296,7 +282,8 @@ extension LoginView {
     private func configureSubviews() {
         [
             entireStackView,
-            pwEyeButton
+            pwEyeButton,
+            socialLoginButtonStackView
         ].forEach {
             addSubview($0)
             $0.translatesAutoresizingMaskIntoConstraints = false
@@ -348,6 +335,19 @@ extension LoginView {
             socialLoginSeparateStackView.heightAnchor.constraint(
                 equalTo: safeAreaLayoutGuide.heightAnchor,
                 multiplier: 40/759
+            ),
+
+            socialLoginButtonStackView.leadingAnchor.constraint(
+                equalTo: safeAreaLayoutGuide.leadingAnchor,
+                constant: 116
+            ),
+            socialLoginButtonStackView.trailingAnchor.constraint(
+                equalTo: safeAreaLayoutGuide.trailingAnchor,
+                constant: -116
+            ),
+            socialLoginButtonStackView.topAnchor.constraint(
+                equalTo: socialLoginSeparateStackView.bottomAnchor,
+                constant: 26
             )
         ])
     }

--- a/Popcorn-iOS/Source/Presentation/SignUp/SignUpScene/Controller/SignUpSecondViewController.swift
+++ b/Popcorn-iOS/Source/Presentation/SignUp/SignUpScene/Controller/SignUpSecondViewController.swift
@@ -8,7 +8,7 @@
 import UIKit
 
 class SignUpSecondViewController: UIViewController {
-    private let signUpSecondView = SignUpSecondView()
+    let signUpSecondView = SignUpSecondView()
     private let screenHeight = UIScreen.main.bounds.height
 
     override func loadView() {

--- a/Popcorn-iOS/Source/Presentation/SignUp/SignUpScene/View/ProfileImagePickerView.swift
+++ b/Popcorn-iOS/Source/Presentation/SignUp/SignUpScene/View/ProfileImagePickerView.swift
@@ -39,6 +39,7 @@ class ProfileImagePickerView: UIView {
         let collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
         collectionView.register(ProfileImageCell.self, forCellWithReuseIdentifier: ProfileImageCell.reuseIdentifier)
         collectionView.allowsMultipleSelection = true
+        collectionView.backgroundColor = .white
         return collectionView
     }()
 


### PR DESCRIPTION
# 배경
#17 카카오톡 소셜로그인 기능을 구현하였습니다.



# 작업 내용

https://github.com/user-attachments/assets/b5a992a5-2b1f-4953-a1af-ff2037f21dfb

https://github.com/user-attachments/assets/6809e874-b797-4de7-b941-d5b679a25fca


## 영상설명
- 첫번째 영상은 카카오톡이 설치되어있지 않은 시뮬레이터의 영상입니다.
테스트할 때, 카카오 계정으로 로그인을 하였으며 필수동의를 이미 한 상태입니다.
- 두번째 영상은 카카오톡이 설치되어있는 실제 아이폰에서의 영상입니다.
카카오 계정으로 이미 로그인이 되어있어서 바로 연동이 되는 모습입니다.
 
## 분기처리
- 카카오 로그인은 카카오톡 앱로그인, 카카오 계정 로그인 2가지로 구현 가능합니다.
권장 사용으로 적혀있는 카카오톡 앱로그인을 우선으로 하여 분기 처리하였습니다.

## 받아오는 정보
- 동의 항목을 미리 정해야하는데 닉네임에 대한 항목만 필수 동의로 하였습니다.
- 토큰과 닉네임을 받아옵니다.

# 테스트 방법
`SceneDelegate`파일의 첫 번째 함수를 다음과 같이 설정하면 시뮬레이션을 해볼 수 있습니다.
```swift
func scene(
      _ scene: UIScene,
      willConnectTo session: UISceneSession,
      options connectionOptions: UIScene.ConnectionOptions
  ) {
      guard let windowScene = (scene as? UIWindowScene) else { return }

      window = UIWindow(windowScene: windowScene)
      let loginViewController = LoginViewController()
      let navigationController = UINavigationController(rootViewController: loginViewController)
      window?.rootViewController = navigationController
      window?.makeKeyAndVisible()
  }
```

# 리뷰 노트
- 토큰에 대한 사용은 아직 구현되어있지 않습니다.
- 받아온 닉네임은 회원가입화면2에서 닉네임으로 쓰일 수 있도록 해두었습니다.
- 카카오톡 SDK설치와 `SceneDelegate`, `AppDelegate`에서의 초기화 과정이 있습니다.