### PR TITLE
[Feat] 회원가입화면1의 정규식에 따른 statusLabel 로직을 구현하였습니다.

### DIFF
--- a/Popcorn-iOS/Source/Presentation/Login/LoginScene/Controller/LoginViewController.swift
+++ b/Popcorn-iOS/Source/Presentation/Login/LoginScene/Controller/LoginViewController.swift
@@ -106,7 +106,7 @@ extension LoginViewController {
         signUpSecondViewController.signUpSecondView.nickNameTextField.text = nickname
         self.navigationController?.pushViewController(signUpSecondViewController, animated: true)
     }
-    
+
     private func sendTokenToServer() {
 
     }

--- a/Popcorn-iOS/Source/Presentation/SignUp/Common/View/SignUpFieldStackView.swift
+++ b/Popcorn-iOS/Source/Presentation/SignUp/Common/View/SignUpFieldStackView.swift
@@ -13,6 +13,9 @@ final class SignUpFieldStackView: UIStackView {
     var textFieldReference: SignUpTextField {
         return signUpTextField
     }
+    var labelReference: SignUpLabel {
+        return signUpLabel
+    }
 
     init(
         labelText: String,

--- a/Popcorn-iOS/Source/Presentation/SignUp/SignUpScene/Controller/SignUpFirstViewController.swift
+++ b/Popcorn-iOS/Source/Presentation/SignUp/SignUpScene/Controller/SignUpFirstViewController.swift
@@ -242,16 +242,16 @@ extension SignUpFirstViewController {
             } else {
                 signUpFirstView.emailField.labelReference.text = ""
                 requestEmailVerification(for: emailText) { [weak self] success in
-                        DispatchQueue.main.async {
-                            if success {
-                                self?.signUpFirstView.emailField.labelReference.textColor = UIColor(.blue)
-                                self?.signUpFirstView.emailField.labelReference.text = "*인증번호가 발송되었습니다."
-                            } else {
-                                self?.signUpFirstView.emailField.labelReference.textColor = UIColor(.red)
-                                self?.signUpFirstView.emailField.labelReference.text = "*인증번호 발송에 실패했습니다. 다시 시도해주세요."
-                            }
+                    DispatchQueue.main.async {
+                        if success {
+                            self?.signUpFirstView.emailField.labelReference.textColor = UIColor(.blue)
+                            self?.signUpFirstView.emailField.labelReference.text = "*인증번호가 발송되었습니다."
+                        } else {
+                            self?.signUpFirstView.emailField.labelReference.textColor = UIColor(.red)
+                            self?.signUpFirstView.emailField.labelReference.text = "*인증번호 발송에 실패했습니다. 다시 시도해주세요."
                         }
                     }
+                }
             }
         } else {
             signUpFirstView.emailField.labelReference.textColor = UIColor(.red)

--- a/Popcorn-iOS/Source/Presentation/SignUp/SignUpScene/Controller/SignUpFirstViewController.swift
+++ b/Popcorn-iOS/Source/Presentation/SignUp/SignUpScene/Controller/SignUpFirstViewController.swift
@@ -201,10 +201,7 @@ extension SignUpFirstViewController {
 extension SignUpFirstViewController {
     private func duplicateCheckButtonTapped() {
         if let idText = signUpFirstView.idField.textFieldReference.text, !idText.isEmpty {
-            if idText.isEmpty {
-                signUpFirstView.idField.labelReference.textColor = UIColor(.red)
-                signUpFirstView.idField.labelReference.text = "*6~12자의 영문과 숫자의 조합으로 입력해주세요."
-            } else if !isValidId(idText) {
+            if !isValidId(idText) {
                 signUpFirstView.idField.labelReference.textColor = UIColor(.red)
                 signUpFirstView.idField.labelReference.text = "*6~12자의 영문과 숫자의 조합으로 입력해주세요."
             } else {
@@ -227,10 +224,28 @@ extension SignUpFirstViewController {
     }
 
     private func requestAuthButtonTapped() {
-        if signUpFirstView.emailField.textFieldReference.text?.isEmpty ?? true {
+        if let emailText = signUpFirstView.emailField.textFieldReference.text, !emailText.isEmpty {
+            if !isValidEmail(emailText) {
+                signUpFirstView.emailField.labelReference.textColor = UIColor(.red)
+                signUpFirstView.emailField.labelReference.text = "*이메일을 올바르게 입력해주세요."
+            } else {
+                signUpFirstView.emailField.labelReference.text = ""
+                requestEmailVerification(for: emailText) { [weak self] success in
+                        DispatchQueue.main.async {
+                            if success {
+                                self?.signUpFirstView.emailField.labelReference.textColor = UIColor(.blue)
+                                self?.signUpFirstView.emailField.labelReference.text = "*인증번호가 발송되었습니다."
+                            } else {
+                                self?.signUpFirstView.emailField.labelReference.textColor = UIColor(.red)
+                                self?.signUpFirstView.emailField.labelReference.text = "*인증번호 발송에 실패했습니다. 다시 시도해주세요."
+                            }
+                        }
+                    }
+            }
+        } else {
             signUpFirstView.emailField.labelReference.textColor = UIColor(.red)
+            signUpFirstView.emailField.labelReference.text = "*이메일을 입력해주세요."
         }
-        // TODO: 서버와 통신
     }
 
     private func nextButtonTapped() {
@@ -250,5 +265,16 @@ extension SignUpFirstViewController {
     private func checkIdDuplication(completion: @escaping (Bool) -> Void) {
         // TODO: 서버와 통신: 아이디 중복 여부를 확인하는 로직
         completion(false)
+    }
+
+    private func requestEmailVerification(for email: String, completion: @escaping (Bool) -> Void) {
+        // TODO: 서버와 통신: email 변수를 서버에 전달, 성공/실패 결과를 completion으로 반환
+        completion(false)
+    }
+
+    private func isValidEmail(_ email: String) -> Bool {
+        let emailRegex = "^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}$"
+        let emailTest = NSPredicate(format: "SELF MATCHES %@", emailRegex)
+        return emailTest.evaluate(with: email)
     }
 }

--- a/Popcorn-iOS/Source/Presentation/SignUp/SignUpScene/Controller/SignUpFirstViewController.swift
+++ b/Popcorn-iOS/Source/Presentation/SignUp/SignUpScene/Controller/SignUpFirstViewController.swift
@@ -183,6 +183,10 @@ extension SignUpFirstViewController {
 // MARK: - Setup AddActions
 extension SignUpFirstViewController {
     private func setupAddActions() {
+        signUpFirstView.duplicateCheckButton.addAction(UIAction { _ in
+            self.duplicateCheckButtonTapped()
+        }, for: .touchUpInside)
+
         signUpFirstView.requestAuthButton.addAction(UIAction { _ in
             self.requestAuthButtonTapped()
         }, for: .touchUpInside)
@@ -195,12 +199,56 @@ extension SignUpFirstViewController {
 
 // MARK: - selector 함수
 extension SignUpFirstViewController {
-    @objc private func requestAuthButtonTapped() {
+    private func duplicateCheckButtonTapped() {
+        if let idText = signUpFirstView.idField.textFieldReference.text, !idText.isEmpty {
+            if idText.isEmpty {
+                signUpFirstView.idField.labelReference.textColor = UIColor(.red)
+                signUpFirstView.idField.labelReference.text = "*6~12자의 영문과 숫자의 조합으로 입력해주세요."
+            } else if !isValidId(idText) {
+                signUpFirstView.idField.labelReference.textColor = UIColor(.red)
+                signUpFirstView.idField.labelReference.text = "*6~12자의 영문과 숫자의 조합으로 입력해주세요."
+            } else {
+                checkIdDuplication { [weak self] isDuplicate in
+                    DispatchQueue.main.async {
+                        if isDuplicate {
+                            self?.signUpFirstView.idField.labelReference.textColor = UIColor(.red)
+                            self?.signUpFirstView.idField.labelReference.text = "*중복된 아이디입니다."
+                        } else {
+                            self?.signUpFirstView.idField.labelReference.textColor = UIColor(.blue)
+                            self?.signUpFirstView.idField.labelReference.text = "*사용 가능한 아이디입니다."
+                        }
+                    }
+                }
+            }
+        } else {
+            signUpFirstView.idField.labelReference.textColor = UIColor(.red)
+            signUpFirstView.idField.labelReference.text = "*6~12자의 영문과 숫자의 조합으로 입력해주세요."
+        }
+    }
+
+    private func requestAuthButtonTapped() {
+        if signUpFirstView.emailField.textFieldReference.text?.isEmpty ?? true {
+            signUpFirstView.emailField.labelReference.textColor = UIColor(.red)
+        }
         // TODO: 서버와 통신
     }
 
-    @objc private func nextButtonTapped() {
+    private func nextButtonTapped() {
         let signUpSecondViewController = SignUpSecondViewController()
         self.navigationController?.pushViewController(signUpSecondViewController, animated: true)
+    }
+}
+
+// MARK: - 서브함수 - 정규식
+extension SignUpFirstViewController {
+    private func isValidId(_ id: String) -> Bool {
+        let idRegex = "^(?=.*[a-zA-Z])(?=.*[0-9])[a-zA-Z0-9]{6,12}$"
+        let idTest = NSPredicate(format: "SELF MATCHES %@", idRegex)
+        return idTest.evaluate(with: id)
+    }
+
+    private func checkIdDuplication(completion: @escaping (Bool) -> Void) {
+        // TODO: 서버와 통신: 아이디 중복 여부를 확인하는 로직
+        completion(false)
     }
 }

--- a/Popcorn-iOS/Source/Presentation/SignUp/SignUpScene/Controller/SignUpFirstViewController.swift
+++ b/Popcorn-iOS/Source/Presentation/SignUp/SignUpScene/Controller/SignUpFirstViewController.swift
@@ -61,6 +61,13 @@ extension SignUpFirstViewController: UITextFieldDelegate {
             signUpFirstView.authNumberTextField
         ].forEach {
             $0.delegate = self
+            $0.addTarget(self, action: #selector(textFieldEditingChanged(_:)), for: .editingChanged)
+        }
+    }
+
+    @objc private func textFieldEditingChanged(_ textField: UITextField) {
+        if textField == signUpFirstView.passwordField.textFieldReference {
+            validatePasswordField()
         }
     }
 
@@ -265,6 +272,27 @@ extension SignUpFirstViewController {
     private func checkIdDuplication(completion: @escaping (Bool) -> Void) {
         // TODO: 서버와 통신: 아이디 중복 여부를 확인하는 로직
         completion(false)
+    }
+
+    private func isValidPassword(_ password: String) -> Bool {
+        let passwordRegex = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[@$!%*?&#])[A-Za-z\\d@$!%*?&#]{8,16}$"
+        let passwordTest = NSPredicate(format: "SELF MATCHES %@", passwordRegex)
+        return passwordTest.evaluate(with: password)
+    }
+
+    private func validatePasswordField() {
+        if let passwordText = signUpFirstView.passwordField.textFieldReference.text, !passwordText.isEmpty {
+            if !isValidPassword(passwordText) {
+                signUpFirstView.passwordField.labelReference.textColor = UIColor(.red)
+                signUpFirstView.passwordField.labelReference.text = "*8~16자, 영문, 숫자, 특수문자를 조합해주세요."
+            } else {
+                signUpFirstView.passwordField.labelReference.textColor = UIColor(.blue)
+                signUpFirstView.passwordField.labelReference.text = "*사용 가능한 비밀번호입니다."
+            }
+        } else {
+            signUpFirstView.passwordField.labelReference.textColor = UIColor(.red)
+            signUpFirstView.passwordField.labelReference.text = "*비밀번호를 입력해주세요."
+        }
     }
 
     private func requestEmailVerification(for email: String, completion: @escaping (Bool) -> Void) {

--- a/Popcorn-iOS/Source/Presentation/SignUp/SignUpScene/Controller/SignUpFirstViewController.swift
+++ b/Popcorn-iOS/Source/Presentation/SignUp/SignUpScene/Controller/SignUpFirstViewController.swift
@@ -270,11 +270,13 @@ extension SignUpFirstViewController {
             validateAuthNumberField { [weak self] isAuthValid in
                 DispatchQueue.main.async {
                     if isAuthValid {
-                        self?.updateAuthNumberLabel(isValid: true, message: " ")
+                        self?.signUpFirstView.authNumberField.labelReference.textColor = UIColor(.blue)
+                        self?.signUpFirstView.authNumberField.labelReference.text = " "
                         let signUpSecondViewController = SignUpSecondViewController()
                         self?.navigationController?.pushViewController(signUpSecondViewController, animated: true)
                     } else {
-                        self?.updateAuthNumberLabel(isValid: false, message: "*인증번호를 다시 입력해주세요.")
+                        self?.signUpFirstView.authNumberField.labelReference.textColor = UIColor(.red)
+                        self?.signUpFirstView.authNumberField.labelReference.text = "*인증번호를 다시 입력해주세요."
                     }
                 }
             }
@@ -283,10 +285,9 @@ extension SignUpFirstViewController {
             signUpFirstView.authNumberField.labelReference.text = "*개인정보를 먼저 입력해주세요."
         }
     }
-
 }
 
-// MARK: - 서브함수 - 정규식
+// MARK: - 서브함수 - Validate
 extension SignUpFirstViewController {
     private func validateNameField() {
         if let nameText = signUpFirstView.nameField.textFieldReference.text, !nameText.isEmpty {
@@ -301,29 +302,6 @@ extension SignUpFirstViewController {
             signUpFirstView.nameField.labelReference.textColor = UIColor(.red)
             signUpFirstView.nameField.labelReference.text = "*이름을 입력해주세요."
         }
-    }
-
-    private func isValidName(_ name: String) -> Bool {
-        let nameRegex = "^[가-힣a-zA-Z]{2,10}$"
-        let nameTest = NSPredicate(format: "SELF MATCHES %@", nameRegex)
-        return nameTest.evaluate(with: name)
-    }
-
-    private func isValidId(_ id: String) -> Bool {
-        let idRegex = "^(?=.*[a-zA-Z])(?=.*[0-9])[a-zA-Z0-9]{6,12}$"
-        let idTest = NSPredicate(format: "SELF MATCHES %@", idRegex)
-        return idTest.evaluate(with: id)
-    }
-
-    private func checkIdDuplication(completion: @escaping (Bool) -> Void) {
-        // TODO: 서버와 통신: 아이디 중복 여부를 확인하는 로직, 중복이 true
-        completion(false)
-    }
-
-    private func isValidPassword(_ password: String) -> Bool {
-        let passwordRegex = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[@$!%*?&#])[A-Za-z\\d@$!%*?&#]{8,16}$"
-        let passwordTest = NSPredicate(format: "SELF MATCHES %@", passwordRegex)
-        return passwordTest.evaluate(with: password)
     }
 
     private func validatePasswordField() {
@@ -357,17 +335,6 @@ extension SignUpFirstViewController {
         }
     }
 
-    private func requestEmailVerification(for email: String, completion: @escaping (Bool) -> Void) {
-        // TODO: 서버와 통신: email 변수를 서버에 전달, 성공/실패 결과를 completion으로 반환
-        completion(true)
-    }
-
-    private func isValidEmail(_ email: String) -> Bool {
-        let emailRegex = "^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}$"
-        let emailTest = NSPredicate(format: "SELF MATCHES %@", emailRegex)
-        return emailTest.evaluate(with: email)
-    }
-
     private func validateAuthNumberField(completion: @escaping (Bool) -> Void) {
         guard let authNumberText = signUpFirstView.authNumberField.textFieldReference.text,
               !authNumberText.isEmpty else {
@@ -379,14 +346,49 @@ extension SignUpFirstViewController {
             completion(isValid)
         }
     }
+}
+
+// MARK: - 서버와 통신: 중복확인버튼, 이메일-인증번호요청버튼, 인증번호확인-다음버튼
+extension SignUpFirstViewController {
+    private func checkIdDuplication(completion: @escaping (Bool) -> Void) {
+        // TODO: 서버와 통신: 아이디 중복 여부를 확인하는 로직, 중복이 true
+        completion(false)
+    }
+
+    private func requestEmailVerification(for email: String, completion: @escaping (Bool) -> Void) {
+        // TODO: 서버와 통신: email 변수를 서버에 전달, 성공/실패 결과를 completion으로 반환
+        completion(true)
+    }
 
     private func verifyAuthNumber(authCode: String, completion: @escaping (Bool) -> Void) {
         // TODO: 서버와 통신하여 인증번호 확인
         completion(true)
     }
+}
 
-    private func updateAuthNumberLabel(isValid: Bool, message: String) {
-        signUpFirstView.authNumberField.labelReference.textColor = isValid ? UIColor(.blue) : UIColor(.red)
-        signUpFirstView.authNumberField.labelReference.text = message
+// MARK: - 서브함수 - 정규식
+extension SignUpFirstViewController {
+    private func isValidName(_ name: String) -> Bool {
+        let nameRegex = "^[가-힣a-zA-Z]{2,10}$"
+        let nameTest = NSPredicate(format: "SELF MATCHES %@", nameRegex)
+        return nameTest.evaluate(with: name)
+    }
+
+    private func isValidId(_ id: String) -> Bool {
+        let idRegex = "^(?=.*[a-zA-Z])(?=.*[0-9])[a-zA-Z0-9]{6,12}$"
+        let idTest = NSPredicate(format: "SELF MATCHES %@", idRegex)
+        return idTest.evaluate(with: id)
+    }
+
+    private func isValidPassword(_ password: String) -> Bool {
+        let passwordRegex = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[@$!%*?&#])[A-Za-z\\d@$!%*?&#]{8,16}$"
+        let passwordTest = NSPredicate(format: "SELF MATCHES %@", passwordRegex)
+        return passwordTest.evaluate(with: password)
+    }
+
+    private func isValidEmail(_ email: String) -> Bool {
+        let emailRegex = "^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}$"
+        let emailTest = NSPredicate(format: "SELF MATCHES %@", emailRegex)
+        return emailTest.evaluate(with: email)
     }
 }

--- a/Popcorn-iOS/Source/Presentation/SignUp/SignUpScene/Controller/SignUpFirstViewController.swift
+++ b/Popcorn-iOS/Source/Presentation/SignUp/SignUpScene/Controller/SignUpFirstViewController.swift
@@ -68,6 +68,8 @@ extension SignUpFirstViewController: UITextFieldDelegate {
     @objc private func textFieldEditingChanged(_ textField: UITextField) {
         if textField == signUpFirstView.passwordField.textFieldReference {
             validatePasswordField()
+        } else if textField == signUpFirstView.confirmPasswordField.textFieldReference {
+            validateConfirmPasswordField()
         }
     }
 
@@ -292,6 +294,22 @@ extension SignUpFirstViewController {
         } else {
             signUpFirstView.passwordField.labelReference.textColor = UIColor(.red)
             signUpFirstView.passwordField.labelReference.text = "*비밀번호를 입력해주세요."
+        }
+    }
+
+    private func validateConfirmPasswordField() {
+        guard let passwordText = signUpFirstView.passwordField.textFieldReference.text,
+              let confirmPasswordText = signUpFirstView.confirmPasswordField.textFieldReference.text else { return }
+
+        if confirmPasswordText.isEmpty {
+            signUpFirstView.confirmPasswordField.labelReference.textColor = UIColor(.red)
+            signUpFirstView.confirmPasswordField.labelReference.text = "*비밀번호 확인을 입력해주세요."
+        } else if confirmPasswordText != passwordText {
+            signUpFirstView.confirmPasswordField.labelReference.textColor = UIColor(.red)
+            signUpFirstView.confirmPasswordField.labelReference.text = "*비밀번호가 일치하지 않습니다."
+        } else {
+            signUpFirstView.confirmPasswordField.labelReference.textColor = UIColor(.blue)
+            signUpFirstView.confirmPasswordField.labelReference.text = "*비밀번호가 일치합니다."
         }
     }
 

--- a/Popcorn-iOS/Source/Presentation/SignUp/SignUpScene/Controller/SignUpFirstViewController.swift
+++ b/Popcorn-iOS/Source/Presentation/SignUp/SignUpScene/Controller/SignUpFirstViewController.swift
@@ -11,6 +11,12 @@ class SignUpFirstViewController: UIViewController {
     private let signUpFirstView = SignUpFirstView()
     private let screenHeight = UIScreen.main.bounds.height
 
+    private var isNameValid = false
+    private var isIdValid = false
+    private var isPasswordValid = false
+    private var isConfirmPasswordValid = false
+    private var isEmailValid = false
+
     override func loadView() {
         view = signUpFirstView
     }
@@ -215,15 +221,18 @@ extension SignUpFirstViewController {
             if !isValidId(idText) {
                 signUpFirstView.idField.labelReference.textColor = UIColor(.red)
                 signUpFirstView.idField.labelReference.text = "*6~12자의 영문과 숫자의 조합으로 입력해주세요."
+                isIdValid = false
             } else {
                 checkIdDuplication { [weak self] isDuplicate in
                     DispatchQueue.main.async {
                         if isDuplicate {
                             self?.signUpFirstView.idField.labelReference.textColor = UIColor(.red)
                             self?.signUpFirstView.idField.labelReference.text = "*중복된 아이디입니다."
+                            self?.isIdValid = false
                         } else {
                             self?.signUpFirstView.idField.labelReference.textColor = UIColor(.blue)
                             self?.signUpFirstView.idField.labelReference.text = "*사용 가능한 아이디입니다."
+                            self?.isIdValid = true
                         }
                     }
                 }
@@ -231,6 +240,7 @@ extension SignUpFirstViewController {
         } else {
             signUpFirstView.idField.labelReference.textColor = UIColor(.red)
             signUpFirstView.idField.labelReference.text = "*6~12자의 영문과 숫자의 조합으로 입력해주세요."
+            isIdValid = false
         }
     }
 
@@ -239,6 +249,7 @@ extension SignUpFirstViewController {
             if !isValidEmail(emailText) {
                 signUpFirstView.emailField.labelReference.textColor = UIColor(.red)
                 signUpFirstView.emailField.labelReference.text = "*이메일을 올바르게 입력해주세요."
+                isEmailValid = false
             } else {
                 signUpFirstView.emailField.labelReference.text = ""
                 requestEmailVerification(for: emailText) { [weak self] success in
@@ -246,9 +257,11 @@ extension SignUpFirstViewController {
                         if success {
                             self?.signUpFirstView.emailField.labelReference.textColor = UIColor(.blue)
                             self?.signUpFirstView.emailField.labelReference.text = "*인증번호가 발송되었습니다."
+                            self?.isEmailValid = true
                         } else {
                             self?.signUpFirstView.emailField.labelReference.textColor = UIColor(.red)
                             self?.signUpFirstView.emailField.labelReference.text = "*인증번호 발송에 실패했습니다. 다시 시도해주세요."
+                            self?.isEmailValid = false
                         }
                     }
                 }
@@ -256,16 +269,11 @@ extension SignUpFirstViewController {
         } else {
             signUpFirstView.emailField.labelReference.textColor = UIColor(.red)
             signUpFirstView.emailField.labelReference.text = "*이메일을 입력해주세요."
+            isEmailValid = false
         }
     }
 
     private func nextButtonTapped() {
-        let isNameValid = signUpFirstView.nameField.labelReference.textColor == UIColor(.blue)
-        let isIdValid = signUpFirstView.idField.labelReference.textColor == UIColor(.blue)
-        let isPasswordValid = signUpFirstView.passwordField.labelReference.textColor == UIColor(.blue)
-        let isConfirmPasswordValid = signUpFirstView.confirmPasswordField.labelReference.textColor == UIColor(.blue)
-        let isEmailValid = signUpFirstView.emailField.labelReference.textColor == UIColor(.blue)
-
         if isNameValid, isIdValid, isPasswordValid, isConfirmPasswordValid, isEmailValid {
             validateAuthNumberField { [weak self] isAuthValid in
                 DispatchQueue.main.async {
@@ -294,13 +302,16 @@ extension SignUpFirstViewController {
             if !isValidName(nameText) {
                 signUpFirstView.nameField.labelReference.textColor = UIColor(.red)
                 signUpFirstView.nameField.labelReference.text = "*이름을 올바르게 입력해주세요."
+                isNameValid = false
             } else {
                 signUpFirstView.nameField.labelReference.textColor = UIColor(.blue)
                 signUpFirstView.nameField.labelReference.text = " "
+                isNameValid = true
             }
         } else {
             signUpFirstView.nameField.labelReference.textColor = UIColor(.red)
             signUpFirstView.nameField.labelReference.text = "*이름을 입력해주세요."
+            isNameValid = false
         }
     }
 
@@ -309,29 +320,38 @@ extension SignUpFirstViewController {
             if !isValidPassword(passwordText) {
                 signUpFirstView.passwordField.labelReference.textColor = UIColor(.red)
                 signUpFirstView.passwordField.labelReference.text = "*8~16자, 영문, 숫자, 특수문자를 조합해주세요."
+                isPasswordValid = false
             } else {
                 signUpFirstView.passwordField.labelReference.textColor = UIColor(.blue)
                 signUpFirstView.passwordField.labelReference.text = "*사용 가능한 비밀번호입니다."
+                isPasswordValid = true
             }
         } else {
             signUpFirstView.passwordField.labelReference.textColor = UIColor(.red)
             signUpFirstView.passwordField.labelReference.text = "*비밀번호를 입력해주세요."
+            isPasswordValid = false
         }
     }
 
     private func validateConfirmPasswordField() {
         guard let passwordText = signUpFirstView.passwordField.textFieldReference.text,
-              let confirmPasswordText = signUpFirstView.confirmPasswordField.textFieldReference.text else { return }
+              let confirmPasswordText = signUpFirstView.confirmPasswordField.textFieldReference.text else {
+            isConfirmPasswordValid = false
+            return
+        }
 
         if confirmPasswordText.isEmpty {
             signUpFirstView.confirmPasswordField.labelReference.textColor = UIColor(.red)
             signUpFirstView.confirmPasswordField.labelReference.text = "*비밀번호 확인을 입력해주세요."
+            isConfirmPasswordValid = false
         } else if confirmPasswordText != passwordText {
             signUpFirstView.confirmPasswordField.labelReference.textColor = UIColor(.red)
             signUpFirstView.confirmPasswordField.labelReference.text = "*비밀번호가 일치하지 않습니다."
+            isConfirmPasswordValid = false
         } else {
             signUpFirstView.confirmPasswordField.labelReference.textColor = UIColor(.blue)
             signUpFirstView.confirmPasswordField.labelReference.text = "*비밀번호가 일치합니다."
+            isConfirmPasswordValid = true
         }
     }
 

--- a/Popcorn-iOS/Source/Presentation/SignUp/SignUpScene/Controller/SignUpFirstViewController.swift
+++ b/Popcorn-iOS/Source/Presentation/SignUp/SignUpScene/Controller/SignUpFirstViewController.swift
@@ -66,7 +66,9 @@ extension SignUpFirstViewController: UITextFieldDelegate {
     }
 
     @objc private func textFieldEditingChanged(_ textField: UITextField) {
-        if textField == signUpFirstView.passwordField.textFieldReference {
+        if textField == signUpFirstView.nameField.textFieldReference {
+            validateNameField()
+        } else if textField == signUpFirstView.passwordField.textFieldReference {
             validatePasswordField()
         } else if textField == signUpFirstView.confirmPasswordField.textFieldReference {
             validateConfirmPasswordField()
@@ -265,6 +267,26 @@ extension SignUpFirstViewController {
 
 // MARK: - 서브함수 - 정규식
 extension SignUpFirstViewController {
+    private func validateNameField() {
+        if let nameText = signUpFirstView.nameField.textFieldReference.text, !nameText.isEmpty {
+            if !isValidName(nameText) {
+                signUpFirstView.nameField.labelReference.textColor = UIColor(.red)
+                signUpFirstView.nameField.labelReference.text = "*이름을 올바르게 입력해주세요."
+            } else {
+                signUpFirstView.nameField.labelReference.text = " "
+            }
+        } else {
+            signUpFirstView.nameField.labelReference.textColor = UIColor(.red)
+            signUpFirstView.nameField.labelReference.text = "*이름을 입력해주세요."
+        }
+    }
+
+    private func isValidName(_ name: String) -> Bool {
+        let nameRegex = "^[가-힣a-zA-Z]{2,10}$"
+        let nameTest = NSPredicate(format: "SELF MATCHES %@", nameRegex)
+        return nameTest.evaluate(with: name)
+    }
+
     private func isValidId(_ id: String) -> Bool {
         let idRegex = "^(?=.*[a-zA-Z])(?=.*[0-9])[a-zA-Z0-9]{6,12}$"
         let idTest = NSPredicate(format: "SELF MATCHES %@", idRegex)

--- a/Popcorn-iOS/Source/Presentation/SignUp/SignUpScene/View/SignUpFirstView.swift
+++ b/Popcorn-iOS/Source/Presentation/SignUp/SignUpScene/View/SignUpFirstView.swift
@@ -72,9 +72,10 @@ class SignUpFirstView: UIView {
         return button
     }()
 
-    let authNumberTextField = SignUpTextField(
-        keyboardType: .numberPad,
-        placeholder: "인증번호를 입력하세요"
+    let authNumberField = SignUpFieldStackView(
+        labelText: "*인증번호를 입력해주세요",
+        placeholder: "인증번호",
+        keyboardType: .numberPad
     )
 
     let nextButton: UIButton = {
@@ -127,7 +128,7 @@ class SignUpFirstView: UIView {
             passwordField,
             confirmPasswordField,
             emailStackView,
-            authNumberTextField
+            authNumberField
         ])
         stackView.axis = .vertical
         let screenHeight = UIScreen.main.bounds.height
@@ -202,7 +203,7 @@ extension SignUpFirstView {
             passwordField.textFieldReference.heightAnchor.constraint(equalTo: duplicateCheckButton.heightAnchor),
             confirmPasswordField.textFieldReference.heightAnchor.constraint(equalTo: duplicateCheckButton.heightAnchor),
             emailField.textFieldReference.heightAnchor.constraint(equalTo: duplicateCheckButton.heightAnchor),
-            authNumberTextField.heightAnchor.constraint(equalTo: duplicateCheckButton.heightAnchor),
+            authNumberField.textFieldReference.heightAnchor.constraint(equalTo: duplicateCheckButton.heightAnchor),
 
             nextButton.heightAnchor.constraint(equalTo: safeAreaLayoutGuide.heightAnchor, multiplier: 56/759)
         ])

--- a/Popcorn-iOS/Source/Presentation/SignUp/SignUpScene/View/SignUpFirstView.swift
+++ b/Popcorn-iOS/Source/Presentation/SignUp/SignUpScene/View/SignUpFirstView.swift
@@ -39,12 +39,14 @@ class SignUpFirstView: UIView {
 
     let passwordField = SignUpFieldStackView(
         labelText: "*비밀번호를 입력해주세요.",
-        placeholder: "비밀번호"
+        placeholder: "비밀번호",
+        isSecureTextEntry: true
     )
 
     let confirmPasswordField = SignUpFieldStackView(
         labelText: "*비밀번호 확인란을 입력해주세요.",
-        placeholder: "비밀번호 확인"
+        placeholder: "비밀번호 확인",
+        isSecureTextEntry: true
     )
 
     let emailField = SignUpFieldStackView(

--- a/Popcorn-iOS/Source/Presentation/SignUp/SignUpScene/View/SignUpFirstView.swift
+++ b/Popcorn-iOS/Source/Presentation/SignUp/SignUpScene/View/SignUpFirstView.swift
@@ -19,7 +19,7 @@ class SignUpFirstView: UIView {
         placeholder: "아이디"
     )
 
-    private let duplicateCheckButton: UIButton = {
+    let duplicateCheckButton: UIButton = {
         let button = UIButton()
         var config = UIButton.Configuration.filled()
         config.baseBackgroundColor = UIColor(resource: .popcornOrange)


### PR DESCRIPTION
# 배경
#21 #68 

<img width="828" alt="스크린샷 2025-01-12 10 39 29" src="https://github.com/user-attachments/assets/4530dd53-4e6c-4649-b5eb-dcb2962dfdd7" />

# 작업 내용
https://github.com/user-attachments/assets/d42b57ec-518c-47e8-952c-5e882ae1df78

## 정규식
- 이름: 한글 또는 영어, 2~10자리
- 아이디: 영문과 숫자의 조합, 6~12자리
- 패스워드: 영문, 숫자와 특수문자의 조합, 8~16자리
- 이메일: (영어, 숫자, 특수문자) + `@` + (영어, 숫자, ., -) + `.`+ (영어, 2글자이상)
 
## 미구현 함수
- `checkIdDuplication`: `duplicateCheckButtonTapped`에서 호출되는 함수로 사용자가 아이디 중복확인을 위해 서버와 통신하는 함수입니다.
- `requestEmailVerification`: `requestAuthButtonTapped`에서 호출되는 함수로 사용자가 인증번호를 메일에서 받기위해 서버와 통신하는 함수입니다.
- `verifyAuthNumber`: `nextButtonTapped`함수 안의 `validateAuthNumberField`에서 호출되는 함수로 사용자가 입력한 인증번호가 올바른지 서버와 통신하는 함수입니다.
- 위의 함수들은 우선적으로 통과되도록 작성해두었습니다.

# 테스트 방법
`SceneDelegate`파일의 첫 번째 함수를 다음과 같이 설정하면 시뮬레이션을 해볼 수 있습니다.
```swift
func scene(
      _ scene: UIScene,
      willConnectTo session: UISceneSession,
      options connectionOptions: UIScene.ConnectionOptions
  ) {
      guard let windowScene = (scene as? UIWindowScene) else { return }

      window = UIWindow(windowScene: windowScene)
      let loginViewController = LoginViewController()
      let navigationController = UINavigationController(rootViewController: loginViewController)
      window?.rootViewController = navigationController
      window?.makeKeyAndVisible()
  }
```

# 리뷰 노트
- 임의로 작성된 정규식은 추후 변경될 수 있으므로 함수단위로 작성하여 파일 하단에 선언했습니다.
- `nextButtonTapped`함수 안에 인증번호를 확인하는 로직이 작성되어있습니다.
- `nextButtonTapped`에서 모든 텍스트필드가 올바르게 작성되었는지 확인하는 로직을 작성하기 위해 `statusLabel` 색상이 `blue`임을 사용했습니다.
- 현재 UI가 `statusLabel`이 `""`이 되면 UI가 변경되도록 설정되어있어 `statusLabel`을 `" "`로 변경되게끔 하였습니다.