### PR TITLE
[Refactor] 메인화면의 프레젠테이션 레이어를 리팩토링합니다.

### DIFF
--- a/Popcorn-iOS.xcodeproj/project.pbxproj
+++ b/Popcorn-iOS.xcodeproj/project.pbxproj
@@ -93,6 +93,7 @@
 		56ED58D32D815B9700046377 /* PopupOverviewResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56ED58D22D815B8A00046377 /* PopupOverviewResponseDTO.swift */; };
 		56ED58D92D81660B00046377 /* InterestCategoryDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56ED58D82D8165FA00046377 /* InterestCategoryDTO.swift */; };
 		56ED58DF2D81783A00046377 /* PopupSectionCategory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56ED58DE2D81783100046377 /* PopupSectionCategory.swift */; };
+		56EF8DEA2DCB43DA00025BEB /* PopupPreviewCellable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56EF8DE92DCB43DA00025BEB /* PopupPreviewCellable.swift */; };
 		56F6D45D2D4FBA0C00C2BEBE /* NewToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56F6D4572D4FBA0C00C2BEBE /* NewToken.swift */; };
 		56F6D45E2D4FBA0C00C2BEBE /* Token.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56F6D45A2D4FBA0C00C2BEBE /* Token.swift */; };
 		56F6D45F2D4FBA0C00C2BEBE /* PopupPreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56F6D4592D4FBA0C00C2BEBE /* PopupPreview.swift */; };
@@ -282,6 +283,7 @@
 		56ED58D22D815B8A00046377 /* PopupOverviewResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopupOverviewResponseDTO.swift; sourceTree = "<group>"; };
 		56ED58D82D8165FA00046377 /* InterestCategoryDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InterestCategoryDTO.swift; sourceTree = "<group>"; };
 		56ED58DE2D81783100046377 /* PopupSectionCategory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopupSectionCategory.swift; sourceTree = "<group>"; };
+		56EF8DE92DCB43DA00025BEB /* PopupPreviewCellable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopupPreviewCellable.swift; sourceTree = "<group>"; };
 		56F00A5F2D6CAD2C002B193D /* Popcorn-iOS.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "Popcorn-iOS.entitlements"; sourceTree = "<group>"; };
 		56F6D4572D4FBA0C00C2BEBE /* NewToken.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewToken.swift; sourceTree = "<group>"; };
 		56F6D4582D4FBA0C00C2BEBE /* PopupInformation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopupInformation.swift; sourceTree = "<group>"; };
@@ -403,6 +405,7 @@
 			children = (
 				562447142D33B657000E94A0 /* Delegate */,
 				565C415E2D20320A0016003A /* MainCarouselViewModelProtocol.swift */,
+				56EF8DE92DCB43DA00025BEB /* PopupPreviewCellable.swift */,
 			);
 			path = Protocol;
 			sourceTree = "<group>";
@@ -1691,6 +1694,7 @@
 				5643991D2D44F10E0031688B /* MultipartBodyEndpoint.swift in Sources */,
 				BCE8FA562D228C5400A7B8E2 /* ResetPwViewController.swift in Sources */,
 				BC6420832D58E03F001ACC51 /* AuthNumResultResponseDTO.swift in Sources */,
+				56EF8DEA2DCB43DA00025BEB /* PopupPreviewCellable.swift in Sources */,
 				BC5F3C212D525CC200248DB0 /* AuthNumRequestDTO.swift in Sources */,
 				56A061282D21697E00BC92A8 /* PopupDetailInfoCollectionViewCell.swift in Sources */,
 				5651F4BD2D66EDA000951B6B /* PopupDetailRepositoryProtocol.swift in Sources */,

--- a/Popcorn-iOS/Source/Data/DTO/MainScene/MainScene/PopupOverviewResponseDTO.swift
+++ b/Popcorn-iOS/Source/Data/DTO/MainScene/MainScene/PopupOverviewResponseDTO.swift
@@ -8,17 +8,17 @@
 import Foundation
 
 struct PopupOverviewResponseDTO: Decodable {
-    let popupId: Int
-    let popupImageUrl: String
-    let popupTitle: String
+    let id: Int
+    let imageUrl: String
+    let title: String
     let startDate: String
     let endDate: String
     let address: String
 
     enum CodingKeys: String, CodingKey {
-        case popupId
-        case popupImageUrl = "popupImage"
-        case popupTitle = "title"
+        case id = "popupId"
+        case imageUrl = "popupImage"
+        case title = "title"
         case startDate = "startedAt"
         case endDate = "endedAt"
         case address = "location"
@@ -32,9 +32,9 @@ extension PopupOverviewResponseDTO {
         let startDate = DateFormatter.apiDateFormatter.date(from: startDate) ?? errorDate
 
         return PopupOverview(
-            popupId: popupId,
-            popupImageUrl: popupImageUrl,
-            popupTitle: popupTitle,
+            id: id,
+            imageUrl: imageUrl,
+            title: title,
             startDate: startDate,
             endDate: endDate,
             address: address

--- a/Popcorn-iOS/Source/Data/DTO/MainScene/MainScene/PopupPreviewResponseDTO.swift
+++ b/Popcorn-iOS/Source/Data/DTO/MainScene/MainScene/PopupPreviewResponseDTO.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 struct PopupPreviewResponseDTO: Decodable {
-    let popupId: Int
+    let id: Int
     let title: String
     let imageUrl: String
     let startDate: String
@@ -17,7 +17,7 @@ struct PopupPreviewResponseDTO: Decodable {
     let interestCategory: String
 
     enum CodingKeys: String, CodingKey {
-        case popupId
+        case id = "popupId"
         case title
         case imageUrl = "popupImage"
         case startDate = "startedAt"
@@ -34,7 +34,7 @@ extension PopupPreviewResponseDTO {
         let startDate = DateFormatter.apiDateFormatter.date(from: startDate) ?? errorDate
 
         return PopupPreview(
-            popupId: popupId,
+            popupId: id,
             popupImageUrl: imageUrl,
             popupTitle: title,
             popupEndDate: endDate,

--- a/Popcorn-iOS/Source/Data/DTO/MainScene/PopupDetailScene/PopupInformationResponseDTO.swift
+++ b/Popcorn-iOS/Source/Data/DTO/MainScene/PopupDetailScene/PopupInformationResponseDTO.swift
@@ -44,9 +44,9 @@ extension PopupInformationResponseDTO {
         let endDate = DateFormatter.apiDateFormatter.date(from: endDate) ?? errorDate
 
         return PopupInformation(
-            popupId: popupId,
-            popupImagesUrl: popupImagesUrl,
-            popupTitle: popupTitle,
+            id: popupId,
+            imageUrls: popupImagesUrl,
+            title: popupTitle,
             startDate: startDate,
             endDate: endDate,
             isPick: isPick,

--- a/Popcorn-iOS/Source/Data/DTO/MainScene/PopupDetailScene/PopupReviewListResponseDTO.swift
+++ b/Popcorn-iOS/Source/Data/DTO/MainScene/PopupDetailScene/PopupReviewListResponseDTO.swift
@@ -41,10 +41,10 @@ extension PopupReviewResponseDTO {
         return PopupReview(
             profileImageUrl: profileImageUrl,
             nickName: nickName,
-            reviewRating: reviewRating,
-            reviewDate: reviewDate,
-            reviewImagesUrl: reviewImagesUrl,
-            reviewText: reviewText,
+            rating: reviewRating,
+            createdAt: reviewDate,
+            reviewImageUrls: reviewImagesUrl,
+            content: reviewText,
             likeCount: likeCount,
             isLiked: isLiked
         )

--- a/Popcorn-iOS/Source/Data/Repositories/MainScene/PopupListRepository.swift
+++ b/Popcorn-iOS/Source/Data/Repositories/MainScene/PopupListRepository.swift
@@ -158,10 +158,10 @@ extension PopupListRepository {
         let closingSoonPopups = mainListResponseDTO.closingSoonPopups.map { $0.toEntity() }
 
         return PopupMainList(
-            recommendedPopups: recommendedPopups,
-            userPickPopups: userPickPopups,
-            userInterestPopup: userInterestPopups,
-            closingSoonPopup: closingSoonPopups
+            todayRecommend: recommendedPopups,
+            userPick: userPickPopups,
+            userInterest: userInterestPopups,
+            closingSoon: closingSoonPopups
         )
     }
 }

--- a/Popcorn-iOS/Source/Domain/Entities/MainScene/MainScene/MainScene/PopupMainList.swift
+++ b/Popcorn-iOS/Source/Domain/Entities/MainScene/MainScene/MainScene/PopupMainList.swift
@@ -8,8 +8,8 @@
 import Foundation
 
 struct PopupMainList {
-    let recommendedPopups: [PopupPreview]
-    let userPickPopups: [PopupPreview]
-    let userInterestPopup: [UserInterestPopup]
-    let closingSoonPopup: [PopupPreview]
+    let todayRecommend: [PopupPreview]
+    let userPick: [PopupPreview]
+    let userInterest: [UserInterestPopup]
+    let closingSoon: [PopupPreview]
 }

--- a/Popcorn-iOS/Source/Domain/Entities/MainScene/MainScene/MainScene/PopupPreview.swift
+++ b/Popcorn-iOS/Source/Domain/Entities/MainScene/MainScene/MainScene/PopupPreview.swift
@@ -8,12 +8,12 @@
 import Foundation
 
 struct PopupPreview {
-    let popupId: Int
-    let popupImageUrl: String
-    let popupTitle: String
-    let popupEndDate: Date
-    let popupStartDate: Date?
-    let popupLocation: String?
+    let id: Int
+    let imageUrl: String
+    let title: String
+    let endDate: Date
+    let startDate: Date?
+    let location: String?
 
     init(
         popupId: Int,
@@ -23,11 +23,11 @@ struct PopupPreview {
         popupStartDate: Date? = nil,
         popupLocation: String? = nil
     ) {
-        self.popupId = popupId
-        self.popupImageUrl = popupImageUrl
-        self.popupTitle = popupTitle
-        self.popupEndDate = popupEndDate
-        self.popupStartDate = popupStartDate
-        self.popupLocation = popupLocation
+        self.id = popupId
+        self.imageUrl = popupImageUrl
+        self.title = popupTitle
+        self.endDate = popupEndDate
+        self.startDate = popupStartDate
+        self.location = popupLocation
     }
 }

--- a/Popcorn-iOS/Source/Domain/Entities/MainScene/MainScene/PopupDetailScene/PopupInformation.swift
+++ b/Popcorn-iOS/Source/Domain/Entities/MainScene/MainScene/PopupDetailScene/PopupInformation.swift
@@ -8,9 +8,9 @@
 import Foundation
 
 struct PopupInformation {
-    let popupId: Int
-    let popupImagesUrl: [String]
-    let popupTitle: String
+    let id: Int
+    let imageUrls: [String]
+    let title: String
     let startDate: Date
     let endDate: Date
     let isPick: Bool

--- a/Popcorn-iOS/Source/Domain/Entities/MainScene/MainScene/PopupDetailScene/PopupReviewList.swift
+++ b/Popcorn-iOS/Source/Domain/Entities/MainScene/MainScene/PopupDetailScene/PopupReviewList.swift
@@ -14,10 +14,10 @@ struct PopupReviewList {
 struct PopupReview {
     let profileImageUrl: String?
     let nickName: String
-    let reviewRating: Float
-    let reviewDate: Date
-    let reviewImagesUrl: [String]?
-    let reviewText: String
+    let rating: Float
+    let createdAt: Date
+    let reviewImageUrls: [String]?
+    let content: String
     let likeCount: Int
     let isLiked: Bool
 }

--- a/Popcorn-iOS/Source/Domain/Entities/MainScene/MainScene/PopupOverviewScene/PopupOverview.swift
+++ b/Popcorn-iOS/Source/Domain/Entities/MainScene/MainScene/PopupOverviewScene/PopupOverview.swift
@@ -8,9 +8,9 @@
 import Foundation
 
 struct PopupOverview {
-    let popupId: Int
-    let popupImageUrl: String
-    let popupTitle: String
+    let id: Int
+    let imageUrl: String
+    let title: String
     let startDate: Date
     let endDate: Date
     let address: String

--- a/Popcorn-iOS/Source/Presentation/MainScene/Common/MainSceneMockDataConstant.swift
+++ b/Popcorn-iOS/Source/Presentation/MainScene/Common/MainSceneMockDataConstant.swift
@@ -65,14 +65,14 @@ struct MainSceneMockDataConstant {
         let mockData = MainSceneMockDataConstant()
 
         let popupInfo = PopupInformation(
-            popupId: 1,
-            popupImagesUrl: [
+            id: 1,
+            imageUrls: [
                 mockData.imageUrls[3],
                 mockData.imageUrls[1],
                 mockData.imageUrls[0],
                 mockData.imageUrls[3]
             ],
-            popupTitle: "팝콘 팝업스토어",
+            title: "팝콘 팝업스토어",
             startDate: Date(),
             endDate: Calendar.current.date(byAdding: .day, value: 50, to: Date())!,
             isPick: true,
@@ -97,40 +97,40 @@ struct MainSceneMockDataConstant {
             PopupReview(
                 profileImageUrl: "https://randomuser.me/api/portraits/men/1.jpg",
                 nickName: "팝콘이1",
-                reviewRating: 4.5,
-                reviewDate: mockData.startDateBefore5,
-                reviewImagesUrl: [mockData.imageUrls[2], mockData.imageUrls[5], mockData.imageUrls[3]],
-                reviewText: "퇴근 후 바로 방문했는데 너무 재밌어요!!!!",
+                rating: 4.5,
+                createdAt: mockData.startDateBefore5,
+                reviewImageUrls: [mockData.imageUrls[2], mockData.imageUrls[5], mockData.imageUrls[3]],
+                content: "퇴근 후 바로 방문했는데 너무 재밌어요!!!!",
                 likeCount: 30,
                 isLiked: false
             ),
             PopupReview(
                 profileImageUrl: "https://randomuser.me/api/portraits/women/2.jpg",
                 nickName: "팝콘 화이팅a",
-                reviewRating: 5,
-                reviewDate: mockData.startDateBefore5,
-                reviewImagesUrl: [mockData.imageUrls[4], mockData.imageUrls[1]],
-                reviewText: "저는 오픈런했는데 사람이 너무 많았어요ㅠ 그래도 추천합니다!!",
+                rating: 5,
+                createdAt: mockData.startDateBefore5,
+                reviewImageUrls: [mockData.imageUrls[4], mockData.imageUrls[1]],
+                content: "저는 오픈런했는데 사람이 너무 많았어요ㅠ 그래도 추천합니다!!",
                 likeCount: 15,
                 isLiked: false
             ),
             PopupReview(
                 profileImageUrl: "https://randomuser.me/api/portraits/women/3.jpg",
                 nickName: "핑핑구",
-                reviewRating: 3.5,
-                reviewDate: mockData.startDateBefore5,
-                reviewImagesUrl: [mockData.imageUrls[3]],
-                reviewText: "구성이 알차고 좋아요. 그런데 사람이 너무 많습니다.",
+                rating: 3.5,
+                createdAt: mockData.startDateBefore5,
+                reviewImageUrls: [mockData.imageUrls[3]],
+                content: "구성이 알차고 좋아요. 그런데 사람이 너무 많습니다.",
                 likeCount: 7,
                 isLiked: true
             ),
             PopupReview(
                 profileImageUrl: "https://randomuser.me/api/portraits/men/4.jpg",
                 nickName: "핑구구구",
-                reviewRating: 4,
-                reviewDate: mockData.startDateBefore5,
-                reviewImagesUrl: [mockData.imageUrls[0], mockData.imageUrls[1], mockData.imageUrls[2]],
-                reviewText: "팝콘 캐릭터 너무 귀여워요~~ 다음에 또 팝업 열리면 무조건 갈듯",
+                rating: 4,
+                createdAt: mockData.startDateBefore5,
+                reviewImageUrls: [mockData.imageUrls[0], mockData.imageUrls[1], mockData.imageUrls[2]],
+                content: "팝콘 캐릭터 너무 귀여워요~~ 다음에 또 팝업 열리면 무조건 갈듯",
                 likeCount: 4,
                 isLiked: false
             )
@@ -145,9 +145,9 @@ struct MainSceneMockDataConstant {
 
         return zip(mockData.popupTitles, zip(imageUrls, mockData.addresses)).enumerated().map { index, data in
             PopupOverview(
-                popupId: index + 1,
-                popupImageUrl: data.1.0,
-                popupTitle: data.0,
+                id: index + 1,
+                imageUrl: data.1.0,
+                title: data.0,
                 startDate: mockData.startDateBefore5,
                 endDate: mockData.endDateAfter10,
                 address: data.1.1

--- a/Popcorn-iOS/Source/Presentation/MainScene/DataSource/MainSceneDataSource.swift
+++ b/Popcorn-iOS/Source/Presentation/MainScene/DataSource/MainSceneDataSource.swift
@@ -72,6 +72,10 @@ extension MainSceneDataSource {
             return PopupPreviewViewData.placeholder
         }
     }
+    
+    func getCarouselImageUrl(at indexPath: IndexPath) -> String {
+        return carouselPopupImageUrls[indexPath.row].popupImageUrl
+    }
 
     func showPlaceholderData() {
         self.carouselPopupImageUrls = []

--- a/Popcorn-iOS/Source/Presentation/MainScene/DataSource/MainSceneDataSource.swift
+++ b/Popcorn-iOS/Source/Presentation/MainScene/DataSource/MainSceneDataSource.swift
@@ -60,19 +60,24 @@ extension MainSceneDataSource {
         return carouselPopupImageUrls[index].popupId
     }
 
-    func item(at indexPath: IndexPath) -> PopupPreviewViewData {
-        switch indexPath.section {
-        case 0:
-            return userPickPopup[indexPath.row]
-        case 1..<(1 + userInterestPopup.count):
-            return userInterestPopup[indexPath.section - 1].popups[indexPath.row]
-        case (1 + userInterestPopup.count):
-            return closingSoonPopup[indexPath.row]
-        default:
-            return PopupPreviewViewData.placeholder
+    func item(for section: MainSceneSection, item: Int) -> PopupPreviewViewData {
+        let placeHolder = PopupPreviewViewData.placeholder
+
+        switch section {
+        case .userPick:
+            guard item < userPickPopup.count else { return placeHolder }
+            return userPickPopup[item]
+        case .userInterest(let index):
+            guard index < userInterestPopup.count, item < userInterestPopup[index].popups.count else {
+                return placeHolder
+            }
+            return userInterestPopup[index].popups[item]
+        case .closingSoon:
+            guard item < closingSoonPopup.count else { return placeHolder }
+            return closingSoonPopup[item]
         }
     }
-    
+
     func getCarouselImageUrl(at indexPath: IndexPath) -> String {
         return carouselPopupImageUrls[indexPath.row].popupImageUrl
     }
@@ -86,8 +91,9 @@ extension MainSceneDataSource {
         self.closingSoonPopup = [PopupPreviewViewData.placeholder]
     }
 
-    func provideUserInterestTitle(sectionOfInterest: Int) -> String {
-        return userInterestPopup[sectionOfInterest].interestCategory
+    func provideUserInterestTitle(for section: MainSceneSection) -> String {
+        guard case .userInterest(let index) = section, index < userInterestPopup.count else { return "" }
+        return userInterestPopup[index].interestCategory
     }
 }
 

--- a/Popcorn-iOS/Source/Presentation/MainScene/DataSource/MainSceneDataSource.swift
+++ b/Popcorn-iOS/Source/Presentation/MainScene/DataSource/MainSceneDataSource.swift
@@ -8,129 +8,75 @@
 import Foundation
 
 final class MainSceneDataSource {
-    private var carouselPopupImageUrls: [PopupPreviewViewData] = []
-    private var userPickPopup: [PopupPreviewViewData] = []
-    private var userInterestPopup: [UserInterestPopupViewData] = []
-    private var closingSoonPopup: [PopupPreviewViewData] = []
+    private var todayRecommend: [PopupPreview] = []
+    private var userPick: [PopupPreview] = []
+    private var userInterest: [(title: String, popups: [PopupPreview])] = []
+    private var closingSoon: [PopupPreview] = []
 }
 
 // MARK: - Input
 extension MainSceneDataSource {
-    func updateData(_ popupMainList: PopupMainList) {
-        self.carouselPopupImageUrls = popupMainList.recommendedPopups.compactMap { PopupPreviewViewData(from: $0)}
-        self.userPickPopup = popupMainList.userPickPopups.compactMap { PopupPreviewViewData(from: $0) }
-        self.closingSoonPopup = popupMainList.closingSoonPopup.compactMap { PopupPreviewViewData(from: $0) }
-
-        self.userInterestPopup = popupMainList.userInterestPopup
-            .map { category in
-                return UserInterestPopupViewData(
-                    interestCategory: CategoryMapper.mapToUserInterestedTitle(category.interestCategory),
-                    popups: category.popups.compactMap { PopupPreviewViewData(from: $0) }
-                )
-            }
-            .sorted { $0.interestCategory < $1.interestCategory }
+    func updateData(_ list: PopupMainList) {
+        self.todayRecommend = list.recommendedPopups
+        self.userPick = list.userPickPopups
+        self.closingSoon = list.closingSoonPopup
+        self.userInterest = list.userInterestPopup
+            .map { (CategoryMapper.mapToUserInterestedTitle($0.interestCategory), $0.popups) }
+            .sorted { $0.title < $1.title }
     }
 
     func updateClosingSoonPopup(_ popups: [PopupPreview]) {
-        self.closingSoonPopup = popups.compactMap { PopupPreviewViewData(from: $0) }
+        self.closingSoon = popups
     }
 }
 
 // MARK: - Output
 extension MainSceneDataSource {
-    func numbersOfPopup(of category: PopupSectionCategory, at index: Int = 0) -> Int {
-        switch category {
-        case .todayRecommend:
-            return carouselPopupImageUrls.count
+    func numberOfPopups(in section: MainSceneSection) -> Int {
+        switch section {
         case .userPick:
-            return userPickPopup.count
-        case .userInterest:
-            return userInterestPopup[index].popups.count
+            return userPick.count
+        case .userInterest(let index):
+            guard index < userInterest.count else { return 0 }
+            return userInterest[index].popups.count
         case .closingSoon:
-            return closingSoonPopup.count
+            return closingSoon.count
         }
+    }
+
+    func numberOfTodayRecommend() -> Int {
+        return todayRecommend.count
     }
 
     func numbersOfInterest() -> Int {
-        return userInterestPopup.count
+        return userInterest.count
     }
 
-    func getCarouselPopupId(at index: Int) -> Int {
-        guard index < carouselPopupImageUrls.count else { return 0 }
-        return carouselPopupImageUrls[index].popupId
-    }
-
-    func item(for section: MainSceneSection, item: Int) -> PopupPreviewViewData {
-        let placeHolder = PopupPreviewViewData.placeholder
-
+    func popup(for section: MainSceneSection, item: Int) -> PopupPreview? {
         switch section {
         case .userPick:
-            guard item < userPickPopup.count else { return placeHolder }
-            return userPickPopup[item]
+            guard item < userPick.count else { return nil }
+            return userPick[item]
         case .userInterest(let index):
-            guard index < userInterestPopup.count, item < userInterestPopup[index].popups.count else {
-                return placeHolder
-            }
-            return userInterestPopup[index].popups[item]
+            guard index < userPick.count, item < userInterest[index].popups.count else { return nil }
+            return userInterest[index].popups[item]
         case .closingSoon:
-            guard item < closingSoonPopup.count else { return placeHolder }
-            return closingSoonPopup[item]
+            guard item < closingSoon.count else { return nil }
+            return closingSoon[item]
         }
     }
 
-    func getCarouselImageUrl(at indexPath: IndexPath) -> String {
-        return carouselPopupImageUrls[indexPath.row].popupImageUrl
+    /// MainCarouselView가 데이터를 채우기 위해 사용하는 메서드
+    func getTodayRecommend(item: Int) -> PopupPreview? {
+        guard item < todayRecommend.count else { return nil }
+        return todayRecommend[item]
     }
 
-    func showPlaceholderData() {
-        self.carouselPopupImageUrls = []
-        self.userPickPopup = [PopupPreviewViewData.placeholder]
-        self.userInterestPopup = [
-            UserInterestPopupViewData(interestCategory: "관심사", popups: [PopupPreviewViewData.placeholder])
-        ]
-        self.closingSoonPopup = [PopupPreviewViewData.placeholder]
-    }
+    func interestCategoryTitle(for section: MainSceneSection) -> String? {
+        guard case .userInterest(let index) = section, index < userInterest.count else {
+            return nil
+        }
 
-    func provideUserInterestTitle(for section: MainSceneSection) -> String {
-        guard case .userInterest(let index) = section, index < userInterestPopup.count else { return "" }
-        return userInterestPopup[index].interestCategory
-    }
-}
-
-// MARK: - Mocking
-extension MainSceneDataSource {
-    func genereateMockData() {
-        let mockPopups = MainSceneMockDataConstant.generatePopupPreview()
-
-        self.carouselPopupImageUrls = [
-            PopupPreviewViewData(from: mockPopups[3]),
-            PopupPreviewViewData(from: mockPopups[1]),
-            PopupPreviewViewData(from: mockPopups[2]),
-            PopupPreviewViewData(from: mockPopups[3])
-        ]
-
-        self.userPickPopup = mockPopups.map { PopupPreviewViewData(from: $0) }
-        self.userInterestPopup = [
-            UserInterestPopupViewData(interestCategory: "캐릭터", popups: [
-                PopupPreviewViewData(from: mockPopups[0]),
-                PopupPreviewViewData(from: mockPopups[2]),
-                PopupPreviewViewData(from: mockPopups[1]),
-                PopupPreviewViewData(from: mockPopups[3])
-            ]),
-            UserInterestPopupViewData(interestCategory: "패션", popups: [
-                PopupPreviewViewData(from: mockPopups[4]),
-                PopupPreviewViewData(from: mockPopups[3]),
-                PopupPreviewViewData(from: mockPopups[2]),
-                PopupPreviewViewData(from: mockPopups[1])
-            ])
-        ]
-
-        self.closingSoonPopup = [
-            PopupPreviewViewData(from: mockPopups[0]),
-            PopupPreviewViewData(from: mockPopups[2]),
-            PopupPreviewViewData(from: mockPopups[3]),
-            PopupPreviewViewData(from: mockPopups[2]),
-            PopupPreviewViewData(from: mockPopups[1])
-        ]
+        return userInterest[index].title
     }
 }

--- a/Popcorn-iOS/Source/Presentation/MainScene/DataSource/MainSceneDataSource.swift
+++ b/Popcorn-iOS/Source/Presentation/MainScene/DataSource/MainSceneDataSource.swift
@@ -17,10 +17,10 @@ final class MainSceneDataSource {
 // MARK: - Input
 extension MainSceneDataSource {
     func updateData(_ list: PopupMainList) {
-        self.todayRecommend = list.recommendedPopups
-        self.userPick = list.userPickPopups
-        self.closingSoon = list.closingSoonPopup
-        self.userInterest = list.userInterestPopup
+        self.todayRecommend = list.todayRecommend
+        self.userPick = list.userPick
+        self.closingSoon = list.closingSoon
+        self.userInterest = list.userInterest
             .map { (CategoryMapper.mapToUserInterestedTitle($0.interestCategory), $0.popups) }
             .sorted { $0.title < $1.title }
     }

--- a/Popcorn-iOS/Source/Presentation/MainScene/MainSceneView/MainSceneViewController.swift
+++ b/Popcorn-iOS/Source/Presentation/MainScene/MainSceneView/MainSceneViewController.swift
@@ -206,35 +206,13 @@ extension MainSceneViewController: UICollectionViewDataSource {
             return UICollectionViewCell()
         }
 
-        if let popupDDay = popupData.popupDDay {
-            mainViewModel.fetchImage(url: popupData.popupImageUrl) { result in
-                switch result {
-                case .success(let imageData):
-                    let image = UIImage(data: imageData) ?? UIImage(resource: .popupPreviewPlaceHolder)
-                    DispatchQueue.main.async {
-                        cell.configureContents(
-                            popupImage: image,
-                            popupTitle: popupData.popupTitle,
-                            dDay: popupDDay
-                        )
-                    }
-                case .failure:
-                    DispatchQueue.main.async {
-                        cell.configureContents(
-                            popupImage: UIImage(resource: .popupPreviewPlaceHolder),
-                            popupTitle: popupData.popupTitle,
-                            dDay: popupDDay
-                        )
-                    }
-                }
+        mainViewModel.fetchImage(url: popupData.popupImageUrl) { result in
+            let image = popupData.convertToImage(from: result)
+            DispatchQueue.main.async {
+                cell.configureContents(with: popupData, image: image)
             }
-        } else {
-            cell.configureContents(
-                popupImage: UIImage(resource: .popupPreviewPlaceHolder),
-                popupTitle: PopupPreviewViewData.placeholder.popupTitle,
-                dDay: PopupPreviewViewData.placeholder.popupDDay!
-            )
         }
+
         return cell
     }
 
@@ -250,32 +228,17 @@ extension MainSceneViewController: UICollectionViewDataSource {
             return UICollectionViewCell()
         }
 
-        if let popupPeriod = popupData.popupPeriod,
-           let popupLocation = popupData.popupLocation {
-            mainViewModel.fetchImage(url: popupData.popupImageUrl) { result in
-                switch result {
-                case .success(let imageData):
-                    let image = UIImage(data: imageData) ?? UIImage(resource: .popupPreviewPlaceHolder)
-                    DispatchQueue.main.async {
-                        cell.configureContents(
-                            popupImage: image,
-                            popupTitle: popupData.popupTitle,
-                            period: popupPeriod,
-                            location: popupLocation
-                        )
-                    }
-                case .failure:
-                    DispatchQueue.main.async {
-                        cell.configureContents(
-                            popupImage: UIImage(resource: .popupPreviewPlaceHolder),
-                            popupTitle: popupData.popupTitle,
-                            period: popupPeriod,
-                            location: popupLocation
-                        )
-                    }
-                }
+        let popupPeriod = popupData.popupPeriod ?? PopupPreviewViewData.placeholder.popupPeriod!
+        let popupLocation = popupData.popupLocation ??  PopupPreviewViewData.placeholder.popupLocation!
+
+        mainViewModel.fetchImage(url: popupData.popupImageUrl) { result in
+            let image = popupData.convertToImage(from: result)
+
+            DispatchQueue.main.async {
+                cell.configureContents(with: popupData, image: image)
             }
         }
+
         return cell
     }
 }
@@ -431,5 +394,18 @@ extension MainSceneViewController {
 extension MainSceneViewController {
     private func mockingData() {
         mainViewModel.fetchMockData()
+    }
+}
+
+// MARK: - Extensions
+extension PopupPreviewViewData {
+    func convertToImage(from result: Result<Data, ImageFetchError>) -> UIImage {
+        switch result {
+        case .success(let data):
+            return UIImage(data: data) ?? UIImage(resource: .popupPreviewPlaceHolder)
+        case .failure(let error):
+            print("팝업 프리뷰 이미지 로딩 실패: \(error.localizedDescription)")
+            return UIImage(resource: .popupPreviewPlaceHolder)
+        }
     }
 }

--- a/Popcorn-iOS/Source/Presentation/MainScene/MainSceneView/MainSceneViewController.swift
+++ b/Popcorn-iOS/Source/Presentation/MainScene/MainSceneView/MainSceneViewController.swift
@@ -35,14 +35,15 @@ final class MainSceneViewController: UIViewController {
         configureSubviews()
         configureLayout()
         bind(to: mainViewModel)
-//        mainViewModel.fetchPopupList()
-        mainViewModel.fetchMockData()
+        mainViewModel.fetchPopupList()
     }
 
     func bind(to viewModel: MainSceneViewModel) {
-        viewModel.fetchPopupImagesErrorPublisher = { [weak self] in
+        viewModel.fetchPopupDataPublisher = { [weak self] in
             guard let self else { return }
-            self.mainCollectionView.reloadData()
+            DispatchQueue.main.async {
+                self.mainCollectionView.reloadData()
+            }
         }
 
         viewModel.fetchPopupImagesErrorPublisher = { [weak self] in

--- a/Popcorn-iOS/Source/Presentation/MainScene/MainSceneView/MainSceneViewController.swift
+++ b/Popcorn-iOS/Source/Presentation/MainScene/MainSceneView/MainSceneViewController.swift
@@ -208,17 +208,18 @@ extension MainSceneViewController: UICollectionViewDataSource {
 
         if let popupDDay = popupData.popupDDay {
             mainViewModel.fetchImage(url: popupData.popupImageUrl) { result in
-                DispatchQueue.main.async {
-                    switch result {
-                    case .success(let imageData):
-                        if let image = UIImage(data: imageData) {
-                            cell.configureContents(
-                                popupImage: image,
-                                popupTitle: popupData.popupTitle,
-                                dDay: popupDDay
-                            )
-                        }
-                    case .failure:
+                switch result {
+                case .success(let imageData):
+                    let image = UIImage(data: imageData) ?? UIImage(resource: .popupPreviewPlaceHolder)
+                    DispatchQueue.main.async {
+                        cell.configureContents(
+                            popupImage: image,
+                            popupTitle: popupData.popupTitle,
+                            dDay: popupDDay
+                        )
+                    }
+                case .failure:
+                    DispatchQueue.main.async {
                         cell.configureContents(
                             popupImage: UIImage(resource: .popupPreviewPlaceHolder),
                             popupTitle: popupData.popupTitle,
@@ -252,20 +253,19 @@ extension MainSceneViewController: UICollectionViewDataSource {
         if let popupPeriod = popupData.popupPeriod,
            let popupLocation = popupData.popupLocation {
             mainViewModel.fetchImage(url: popupData.popupImageUrl) { result in
-                DispatchQueue.main.async {
-                    switch result {
-                    case .success(let imageData):
-                        DispatchQueue.main.async {
-                            if let image = UIImage(data: imageData) {
-                                cell.configureContents(
-                                    popupImage: image,
-                                    popupTitle: popupData.popupTitle,
-                                    period: popupPeriod,
-                                    location: popupLocation
-                                )
-                            }
-                        }
-                    case .failure:
+                switch result {
+                case .success(let imageData):
+                    let image = UIImage(data: imageData) ?? UIImage(resource: .popupPreviewPlaceHolder)
+                    DispatchQueue.main.async {
+                        cell.configureContents(
+                            popupImage: image,
+                            popupTitle: popupData.popupTitle,
+                            period: popupPeriod,
+                            location: popupLocation
+                        )
+                    }
+                case .failure:
+                    DispatchQueue.main.async {
                         cell.configureContents(
                             popupImage: UIImage(resource: .popupPreviewPlaceHolder),
                             popupTitle: popupData.popupTitle,
@@ -275,13 +275,6 @@ extension MainSceneViewController: UICollectionViewDataSource {
                     }
                 }
             }
-        } else {
-            cell.configureContents(
-                popupImage: UIImage(resource: .popupPreviewPlaceHolder),
-                popupTitle: PopupPreviewViewData.placeholder.popupTitle,
-                period: PopupPreviewViewData.placeholder.popupPeriod!,
-                location: PopupPreviewViewData.placeholder.popupLocation!
-            )
         }
         return cell
     }

--- a/Popcorn-iOS/Source/Presentation/MainScene/MainSceneView/MainSceneViewController.swift
+++ b/Popcorn-iOS/Source/Presentation/MainScene/MainSceneView/MainSceneViewController.swift
@@ -109,21 +109,20 @@ extension MainSceneViewController {
 // MARK: - Configure CollectionView DataSource
 extension MainSceneViewController: UICollectionViewDataSource {
     func numberOfSections(in collectionView: UICollectionView) -> Int {
-        return 2 + mainViewModel.getDataSource().numbersOfInterest()
+        let sections = mainViewModel.sections
+        return sections.count
     }
 
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        let numberOfInterest = mainViewModel.getDataSource().numbersOfInterest()
+        let section = mainViewModel.sections[section]
 
         switch section {
-        case 0:
-            return mainViewModel.getDataSource().numbersOfPopup(of: .userPick)
-        case 1..<(1 + numberOfInterest):
-            return mainViewModel.getDataSource().numbersOfPopup(of: .userInterest(.none), at: section - 1)
-        case (1 + numberOfInterest):
-            return mainViewModel.getDataSource().numbersOfPopup(of: .closingSoon)
-        default:
-            return 0
+        case .userPick:
+            return mainViewModel.numberOfPopups(in: .userPick)
+        case .userInterest(let index):
+            return mainViewModel.numberOfPopups(in: .userInterest(index: index))
+        case .closingSoon:
+            return mainViewModel.numberOfPopups(in: .closingSoon)
         }
     }
 
@@ -131,132 +130,19 @@ extension MainSceneViewController: UICollectionViewDataSource {
         _ collectionView: UICollectionView,
         cellForItemAt indexPath: IndexPath
     ) -> UICollectionViewCell {
-        let numbersOfInterest = mainViewModel.getDataSource().numbersOfInterest()
-        let popupData = mainViewModel.getDataSource().item(at: indexPath)
+        let section = mainViewModel.sections[indexPath.section]
+        let popupData = mainViewModel.getPopup(for: section, at: indexPath.item)
 
-        switch indexPath.section {
-        case 0:
-            guard let cell = collectionView.dequeueReusableCell(
-                withReuseIdentifier: PickOrInterestCell.reuseIdentifier,
-                for: indexPath
-            ) as? PickOrInterestCell else {
-                return UICollectionViewCell()
-            }
-
-            if let popupDDay = popupData.popupDDay {
-                mainViewModel.fetchImage(url: popupData.popupImageUrl) { result in
-                    DispatchQueue.main.async {
-                        switch result {
-                        case .success(let imageData):
-                            if let image = UIImage(data: imageData) {
-                                cell.configureContents(
-                                    popupImage: image,
-                                    popupTitle: popupData.popupTitle,
-                                    dDay: popupDDay
-                                )
-                            }
-                        case .failure:
-                            cell.configureContents(
-                                popupImage: UIImage(resource: .popupPreviewPlaceHolder),
-                                popupTitle: popupData.popupTitle,
-                                dDay: popupDDay
-                            )
-                        }
-                    }
-                }
-            } else {
-                cell.configureContents(
-                    popupImage: UIImage(resource: .popupPreviewPlaceHolder),
-                    popupTitle: PopupPreviewViewData.placeholder.popupTitle,
-                    dDay: PopupPreviewViewData.placeholder.popupDDay!
-                )
-            }
+        switch section {
+        case .userPick:
+            let cell = configurePickOrInterestCell(collectionView, for: indexPath, popupData)
             return cell
-
-        case (1..<(1 + numbersOfInterest)):
-            guard let cell = collectionView.dequeueReusableCell(
-                withReuseIdentifier: PickOrInterestCell.reuseIdentifier,
-                for: indexPath
-            ) as? PickOrInterestCell else {
-                return UICollectionViewCell()
-            }
-
-            if let popupDDay = popupData.popupDDay {
-                mainViewModel.fetchImage(url: popupData.popupImageUrl) { result in
-                    DispatchQueue.main.async {
-                        switch result {
-                        case .success(let imageData):
-                            if let image = UIImage(data: imageData) {
-                                cell.configureContents(
-                                    popupImage: image,
-                                    popupTitle: popupData.popupTitle,
-                                    dDay: popupDDay
-                                )
-                            }
-                        case .failure:
-                            cell.configureContents(
-                                popupImage: UIImage(resource: .popupPreviewPlaceHolder),
-                                popupTitle: popupData.popupTitle,
-                                dDay: popupDDay
-                            )
-                        }
-                    }
-                }
-            } else {
-                cell.configureContents(
-                    popupImage: UIImage(resource: .popupPreviewPlaceHolder),
-                    popupTitle: PopupPreviewViewData.placeholder.popupTitle,
-                    dDay: PopupPreviewViewData.placeholder.popupDDay!
-                )
-            }
+        case .userInterest:
+            let cell = configurePickOrInterestCell(collectionView, for: indexPath, popupData)
             return cell
-
-        case (1 + numbersOfInterest):
-            guard let cell = collectionView.dequeueReusableCell(
-                withReuseIdentifier: ClosingSoonPopupCell.reuseIdentifier,
-                for: indexPath
-            ) as? ClosingSoonPopupCell else {
-                return UICollectionViewCell()
-            }
-
-            if let popupPeriod = popupData.popupPeriod,
-               let popupLocation = popupData.popupLocation {
-                mainViewModel.fetchImage(url: popupData.popupImageUrl) { result in
-                    DispatchQueue.main.async {
-                        switch result {
-                        case .success(let imageData):
-                            DispatchQueue.main.async {
-                                if let image = UIImage(data: imageData) {
-                                    cell.configureContents(
-                                        popupImage: image,
-                                        popupTitle: popupData.popupTitle,
-                                        period: popupPeriod,
-                                        location: popupLocation
-                                    )
-                                }
-                            }
-                        case .failure:
-                            cell.configureContents(
-                                popupImage: UIImage(resource: .popupPreviewPlaceHolder),
-                                popupTitle: popupData.popupTitle,
-                                period: popupPeriod,
-                                location: popupLocation
-                            )
-                        }
-                    }
-                }
-            } else {
-                cell.configureContents(
-                    popupImage: UIImage(resource: .popupPreviewPlaceHolder),
-                    popupTitle: PopupPreviewViewData.placeholder.popupTitle,
-                    period: PopupPreviewViewData.placeholder.popupPeriod!,
-                    location: PopupPreviewViewData.placeholder.popupLocation!
-                )
-            }
-
+        case .closingSoon:
+            let cell = configureClosingSoonPopupCell(collectionView, for: indexPath, popupData)
             return cell
-        default:
-            return UICollectionViewCell()
         }
     }
 
@@ -265,8 +151,10 @@ extension MainSceneViewController: UICollectionViewDataSource {
         viewForSupplementaryElementOfKind kind: String,
         at indexPath: IndexPath
     ) -> UICollectionReusableView {
-        switch indexPath.section {
-        case 0:
+        let section = mainViewModel.sections[indexPath.section]
+
+        switch section {
+        case .userPick:
             guard let carouselHeader = collectionView.dequeueReusableSupplementaryView(
                 ofKind: UICollectionView.elementKindSectionHeader,
                 withReuseIdentifier: MainCarouselPickHeaderView.reuseIdentifier,
@@ -278,7 +166,7 @@ extension MainSceneViewController: UICollectionViewDataSource {
             carouselHeader.assignDelegate(self)
             carouselHeader.configureContents(headerTitle: "찜 목록", viewModel: mainViewModel)
             return carouselHeader
-        case 1..<(1 + mainViewModel.getDataSource().numbersOfInterest()):
+        case .userInterest:
             guard let header = collectionView.dequeueReusableSupplementaryView(
                 ofKind: UICollectionView.elementKindSectionHeader,
                 withReuseIdentifier: MainCollectionHeaderView.reuseIdentifier,
@@ -287,14 +175,12 @@ extension MainSceneViewController: UICollectionViewDataSource {
                 return UICollectionReusableView()
             }
 
-            let headerTitle = mainViewModel
-                .getDataSource()
-                .provideUserInterestTitle(sectionOfInterest: indexPath.section - 1)
+            let headerTitle = mainViewModel.getInterestCategoryTitle(for: section)
 
             header.assignDelegate(self)
             header.configureContents(headerTitle: headerTitle)
             return header
-        case (1 + mainViewModel.getDataSource().numbersOfInterest()):
+        case .closingSoon:
             guard let header = collectionView.dequeueReusableSupplementaryView(
                 ofKind: UICollectionView.elementKindSectionHeader,
                 withReuseIdentifier: MainCollectionHeaderView.reuseIdentifier,
@@ -305,9 +191,99 @@ extension MainSceneViewController: UICollectionViewDataSource {
 
             header.configureContents(headerTitle: "지금 놓치면 안 될 팝업스토어", shouldHiddenShowButton: true)
             return header
-        default:
-            return UICollectionReusableView()
         }
+    }
+
+    private func configurePickOrInterestCell(
+        _ collectionView: UICollectionView,
+        for indexPath: IndexPath,
+        _ popupData: PopupPreviewViewData
+    ) -> UICollectionViewCell {
+        guard let cell = collectionView.dequeueReusableCell(
+            withReuseIdentifier: PickOrInterestCell.reuseIdentifier,
+            for: indexPath
+        ) as? PickOrInterestCell else {
+            return UICollectionViewCell()
+        }
+
+        if let popupDDay = popupData.popupDDay {
+            mainViewModel.fetchImage(url: popupData.popupImageUrl) { result in
+                DispatchQueue.main.async {
+                    switch result {
+                    case .success(let imageData):
+                        if let image = UIImage(data: imageData) {
+                            cell.configureContents(
+                                popupImage: image,
+                                popupTitle: popupData.popupTitle,
+                                dDay: popupDDay
+                            )
+                        }
+                    case .failure:
+                        cell.configureContents(
+                            popupImage: UIImage(resource: .popupPreviewPlaceHolder),
+                            popupTitle: popupData.popupTitle,
+                            dDay: popupDDay
+                        )
+                    }
+                }
+            }
+        } else {
+            cell.configureContents(
+                popupImage: UIImage(resource: .popupPreviewPlaceHolder),
+                popupTitle: PopupPreviewViewData.placeholder.popupTitle,
+                dDay: PopupPreviewViewData.placeholder.popupDDay!
+            )
+        }
+        return cell
+    }
+
+    private func configureClosingSoonPopupCell(
+        _ collectionView: UICollectionView,
+        for indexPath: IndexPath,
+        _ popupData: PopupPreviewViewData
+    ) -> UICollectionViewCell {
+        guard let cell = collectionView.dequeueReusableCell(
+            withReuseIdentifier: ClosingSoonPopupCell.reuseIdentifier,
+            for: indexPath
+        ) as? ClosingSoonPopupCell else {
+            return UICollectionViewCell()
+        }
+
+        if let popupPeriod = popupData.popupPeriod,
+           let popupLocation = popupData.popupLocation {
+            mainViewModel.fetchImage(url: popupData.popupImageUrl) { result in
+                DispatchQueue.main.async {
+                    switch result {
+                    case .success(let imageData):
+                        DispatchQueue.main.async {
+                            if let image = UIImage(data: imageData) {
+                                cell.configureContents(
+                                    popupImage: image,
+                                    popupTitle: popupData.popupTitle,
+                                    period: popupPeriod,
+                                    location: popupLocation
+                                )
+                            }
+                        }
+                    case .failure:
+                        cell.configureContents(
+                            popupImage: UIImage(resource: .popupPreviewPlaceHolder),
+                            popupTitle: popupData.popupTitle,
+                            period: popupPeriod,
+                            location: popupLocation
+                        )
+                    }
+                }
+            }
+        } else {
+            cell.configureContents(
+                popupImage: UIImage(resource: .popupPreviewPlaceHolder),
+                popupTitle: PopupPreviewViewData.placeholder.popupTitle,
+                period: PopupPreviewViewData.placeholder.popupPeriod!,
+                location: PopupPreviewViewData.placeholder.popupLocation!
+            )
+        }
+        return cell
     }
 }
 
@@ -316,16 +292,15 @@ extension MainSceneViewController {
     private func generateCollectionViewLayout() -> UICollectionViewCompositionalLayout {
         return UICollectionViewCompositionalLayout { [weak self] sectionIndex, _ in
             guard let self else { return nil }
+            let layout = mainViewModel.sections[sectionIndex]
 
-            switch sectionIndex {
-            case 0:
+            switch layout {
+            case .userPick:
                 return generateHorizontalLayout(isPickSection: true)
-            case 1..<(1 + self.mainViewModel.getDataSource().numbersOfInterest()):
+            case .userInterest:
                 return generateHorizontalLayout()
-            case self.mainViewModel.getDataSource().numbersOfInterest() + 1:
+            case .closingSoon:
                 return generateVerticalGridLayout()
-            default:
-                return generateHorizontalLayout()
             }
         }
     }
@@ -409,7 +384,7 @@ extension MainSceneViewController: UICollectionViewDelegate, MainCarouselViewDel
     }
 
     func navigateToPopupDetailViewController(selectedIndex: Int) {
-        let popupId = mainViewModel.getDataSource().getCarouselPopupId(at: selectedIndex)
+        let popupId = mainViewModel.getTodayRecommendPopupId(at: selectedIndex)
 
         let detailViewController = PopupDetailViewController(
             viewModel: DIContainer.shared.resolve(PopupDetailViewModel.self),

--- a/Popcorn-iOS/Source/Presentation/MainScene/MainSceneView/MainSceneViewController.swift
+++ b/Popcorn-iOS/Source/Presentation/MainScene/MainSceneView/MainSceneViewController.swift
@@ -132,18 +132,30 @@ extension MainSceneViewController: UICollectionViewDataSource {
     ) -> UICollectionViewCell {
         let section = mainViewModel.sections[indexPath.section]
         let popupData = mainViewModel.getPopup(for: section, at: indexPath.item)
+        let reuseIdentifier: String
 
         switch section {
-        case .userPick:
-            let cell = configurePickOrInterestCell(collectionView, for: indexPath, popupData)
-            return cell
-        case .userInterest:
-            let cell = configurePickOrInterestCell(collectionView, for: indexPath, popupData)
-            return cell
+        case .userPick, .userInterest:
+            reuseIdentifier = PickOrInterestCell.reuseIdentifier
         case .closingSoon:
-            let cell = configureClosingSoonPopupCell(collectionView, for: indexPath, popupData)
-            return cell
+            reuseIdentifier = ClosingSoonPopupCell.reuseIdentifier
         }
+
+        guard let cell = collectionView.dequeueReusableCell(
+            withReuseIdentifier: reuseIdentifier,
+            for: indexPath
+        ) as? PopupPreviewCellable else {
+            return UICollectionViewCell()
+        }
+
+        mainViewModel.fetchImage(url: popupData.popupImageUrl) { result in
+            let image = popupData.convertToImage(from: result)
+            DispatchQueue.main.async {
+                cell.configure(with: popupData, image: image)
+            }
+        }
+
+        return cell as! UICollectionViewCell
     }
 
     func collectionView(
@@ -192,54 +204,6 @@ extension MainSceneViewController: UICollectionViewDataSource {
             header.configureContents(headerTitle: "지금 놓치면 안 될 팝업스토어", shouldHiddenShowButton: true)
             return header
         }
-    }
-
-    private func configurePickOrInterestCell(
-        _ collectionView: UICollectionView,
-        for indexPath: IndexPath,
-        _ popupData: PopupPreviewViewData
-    ) -> UICollectionViewCell {
-        guard let cell = collectionView.dequeueReusableCell(
-            withReuseIdentifier: PickOrInterestCell.reuseIdentifier,
-            for: indexPath
-        ) as? PickOrInterestCell else {
-            return UICollectionViewCell()
-        }
-
-        mainViewModel.fetchImage(url: popupData.popupImageUrl) { result in
-            let image = popupData.convertToImage(from: result)
-            DispatchQueue.main.async {
-                cell.configureContents(with: popupData, image: image)
-            }
-        }
-
-        return cell
-    }
-
-    private func configureClosingSoonPopupCell(
-        _ collectionView: UICollectionView,
-        for indexPath: IndexPath,
-        _ popupData: PopupPreviewViewData
-    ) -> UICollectionViewCell {
-        guard let cell = collectionView.dequeueReusableCell(
-            withReuseIdentifier: ClosingSoonPopupCell.reuseIdentifier,
-            for: indexPath
-        ) as? ClosingSoonPopupCell else {
-            return UICollectionViewCell()
-        }
-
-        let popupPeriod = popupData.popupPeriod ?? PopupPreviewViewData.placeholder.popupPeriod!
-        let popupLocation = popupData.popupLocation ??  PopupPreviewViewData.placeholder.popupLocation!
-
-        mainViewModel.fetchImage(url: popupData.popupImageUrl) { result in
-            let image = popupData.convertToImage(from: result)
-
-            DispatchQueue.main.async {
-                cell.configureContents(with: popupData, image: image)
-            }
-        }
-
-        return cell
     }
 }
 

--- a/Popcorn-iOS/Source/Presentation/MainScene/MainSceneView/ReusableView/ClosingSoonPopupCell.swift
+++ b/Popcorn-iOS/Source/Presentation/MainScene/MainSceneView/ReusableView/ClosingSoonPopupCell.swift
@@ -83,7 +83,7 @@ final class ClosingSoonPopupCell: UICollectionViewCell {
         fatalError("init(coder:) has not been implemented")
     }
 
-    private func configure(popupImage: UIImage, popupTitle: String, period: String, location: String) {
+    private func configureContents(popupImage: UIImage, popupTitle: String, period: String, location: String) {
         popupImageView.image = popupImage
         popupTitleLabel.text = popupTitle
         popupPeriodLabel.text = period
@@ -92,11 +92,11 @@ final class ClosingSoonPopupCell: UICollectionViewCell {
 }
 
 // MARK: - Public Interface
-extension ClosingSoonPopupCell {
-    func configureContents(with popupData: PopupPreviewViewData, image: UIImage) {
+extension ClosingSoonPopupCell: PopupPreviewCellable {
+    func configure(with popupData: PopupPreviewViewData, image: UIImage) {
         let popupPeriod = popupData.popupPeriod ?? PopupPreviewViewData.placeholder.popupPeriod!
         let popupLocation = popupData.popupLocation ??  PopupPreviewViewData.placeholder.popupLocation!
-        configure(popupImage: image, popupTitle: popupData.popupTitle, period: popupPeriod, location: popupLocation)
+        configureContents(popupImage: image, popupTitle: popupData.popupTitle, period: popupPeriod, location: popupLocation)
     }
 }
 

--- a/Popcorn-iOS/Source/Presentation/MainScene/MainSceneView/ReusableView/ClosingSoonPopupCell.swift
+++ b/Popcorn-iOS/Source/Presentation/MainScene/MainSceneView/ReusableView/ClosingSoonPopupCell.swift
@@ -82,15 +82,21 @@ final class ClosingSoonPopupCell: UICollectionViewCell {
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-}
 
-// MARK: - Public Interface
-extension ClosingSoonPopupCell {
-    func configureContents(popupImage: UIImage, popupTitle: String, period: String, location: String) {
+    private func configure(popupImage: UIImage, popupTitle: String, period: String, location: String) {
         popupImageView.image = popupImage
         popupTitleLabel.text = popupTitle
         popupPeriodLabel.text = period
         popupLocationLabel.text = location
+    }
+}
+
+// MARK: - Public Interface
+extension ClosingSoonPopupCell {
+    func configureContents(with popupData: PopupPreviewViewData, image: UIImage) {
+        let popupPeriod = popupData.popupPeriod ?? PopupPreviewViewData.placeholder.popupPeriod!
+        let popupLocation = popupData.popupLocation ??  PopupPreviewViewData.placeholder.popupLocation!
+        configure(popupImage: image, popupTitle: popupData.popupTitle, period: popupPeriod, location: popupLocation)
     }
 }
 

--- a/Popcorn-iOS/Source/Presentation/MainScene/MainSceneView/ReusableView/PickOrInterestCell.swift
+++ b/Popcorn-iOS/Source/Presentation/MainScene/MainSceneView/ReusableView/PickOrInterestCell.swift
@@ -49,7 +49,7 @@ final class PickOrInterestCell: UICollectionViewCell {
         fatalError("init(coder:) has not been implemented")
     }
 
-    private func configure(popupImage: UIImage, popupTitle: String, dDay: String) {
+    private func configureContents(popupImage: UIImage, popupTitle: String, dDay: String) {
         popupImageView.image = popupImage
         popupTitleLabel.text = popupTitle
         dDayLabel.text = dDay
@@ -57,10 +57,10 @@ final class PickOrInterestCell: UICollectionViewCell {
 }
 
 // MARK: - Public Interface
-extension PickOrInterestCell {
-    func configureContents(with popupData: PopupPreviewViewData, image: UIImage) {
+extension PickOrInterestCell: PopupPreviewCellable {
+    func configure(with popupData: PopupPreviewViewData, image: UIImage) {
         let popupDDay = popupData.popupDDay ?? PopupPreviewViewData.placeholder.popupDDay!
-        configure(popupImage: image, popupTitle: popupData.popupTitle, dDay: popupDDay)
+        configureContents(popupImage: image, popupTitle: popupData.popupTitle, dDay: popupDDay)
     }
 }
 

--- a/Popcorn-iOS/Source/Presentation/MainScene/MainSceneView/ReusableView/PickOrInterestCell.swift
+++ b/Popcorn-iOS/Source/Presentation/MainScene/MainSceneView/ReusableView/PickOrInterestCell.swift
@@ -48,14 +48,19 @@ final class PickOrInterestCell: UICollectionViewCell {
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
+
+    private func configure(popupImage: UIImage, popupTitle: String, dDay: String) {
+        popupImageView.image = popupImage
+        popupTitleLabel.text = popupTitle
+        dDayLabel.text = dDay
+    }
 }
 
 // MARK: - Public Interface
 extension PickOrInterestCell {
-    func configureContents(popupImage: UIImage, popupTitle: String, dDay: String) {
-        popupImageView.image = popupImage
-        popupTitleLabel.text = popupTitle
-        dDayLabel.text = dDay
+    func configureContents(with popupData: PopupPreviewViewData, image: UIImage) {
+        let popupDDay = popupData.popupDDay ?? PopupPreviewViewData.placeholder.popupDDay!
+        configure(popupImage: image, popupTitle: popupData.popupTitle, dDay: popupDDay)
     }
 }
 

--- a/Popcorn-iOS/Source/Presentation/MainScene/Protocol/PopupPreviewCellable.swift
+++ b/Popcorn-iOS/Source/Presentation/MainScene/Protocol/PopupPreviewCellable.swift
@@ -1,0 +1,12 @@
+//
+//  ConfigurablePopupPreviewCell.swift
+//  Popcorn-iOS
+//
+//  Created by 제민우 on 5/7/25.
+//
+
+import UIKit
+
+protocol PopupPreviewCellable {
+    func configure(with popupData: PopupPreviewViewData, image: UIImage)
+}

--- a/Popcorn-iOS/Source/Presentation/MainScene/ViewModel/MainSceneViewModel.swift
+++ b/Popcorn-iOS/Source/Presentation/MainScene/ViewModel/MainSceneViewModel.swift
@@ -38,18 +38,13 @@ final class MainSceneViewModel: MainCarouselViewModelProtocol {
         self.mainSceneDataSource = mainSceneDataSource
     }
 
-    func getDataSource() -> MainSceneDataSource {
-        return mainSceneDataSource
-    }
-
     private func updateSections() {
         sections = buildSections()
     }
 
     private func buildSections() -> [MainSceneSection] {
         var sections = [MainSceneSection]()
-        
-        if mainSceneDataSource.numbersOfPopup(of: .userPick) > 0 {
+        if mainSceneDataSource.numberOfPopups(in: .userPick) > 0 {
             sections.append(.userPick)
         }
 
@@ -57,7 +52,7 @@ final class MainSceneViewModel: MainCarouselViewModelProtocol {
         sections += (0..<interestCount).map { .userInterest(index: $0) }
 
         sections.append(.closingSoon)
-        
+
         return sections
     }
 }
@@ -84,7 +79,7 @@ extension MainSceneViewModel {
                 fetchPopupDataPublisher?()
             case .failure(let error):
                 print(error)
-                self.mainSceneDataSource.showPlaceholderData()
+//                self.mainSceneDataSource.showPlaceholderData()
             }
         }
     }
@@ -107,19 +102,47 @@ extension MainSceneViewModel {
     }
 
     func fetchMockData() {
-        mainSceneDataSource.genereateMockData()
+//        mainSceneDataSource.genereateMockData()
         fetchPopupDataPublisher?()
+    }
+}
+
+// MARK: - DataSource
+extension MainSceneViewModel {
+    func numberOfPopups(in section: MainSceneSection) -> Int {
+        return mainSceneDataSource.numberOfPopups(in: section)
+    }
+
+    func numberOfInterest() -> Int {
+        return mainSceneDataSource.numbersOfInterest()
+    }
+
+    func getPopup(for section: MainSceneSection, at index: Int) -> PopupPreviewViewData {
+        guard let popup = mainSceneDataSource.popup(for: section, item: index) else {
+            return PopupPreviewViewData.placeholder
+        }
+
+        return PopupPreviewViewData(from: popup)
+    }
+
+    func getTodayRecommendPopupId(at index: Int) -> Int {
+        // TODO: - -1 반환 대신 nil 리턴, detailViewController 생성자에서 popupId가 nil일 때 처리.
+        return mainSceneDataSource.getTodayRecommend(item: index)?.popupId ?? -1
+    }
+
+    func getInterestCategoryTitle(for section: MainSceneSection) -> String {
+        mainSceneDataSource.interestCategoryTitle(for: section) ?? ""
     }
 }
 
 // MARK: - Implement MainCarouselDataSource
 extension MainSceneViewModel {
     func numbersOfCarouselImage() -> Int {
-        return mainSceneDataSource.numbersOfPopup(of: .todayRecommend)
+        return mainSceneDataSource.numberOfTodayRecommend()
     }
 
     func provideCarouselImageUrl(at indexPath: IndexPath) -> String {
-        return mainSceneDataSource.getCarouselImageUrl(at: indexPath)
+        return mainSceneDataSource.getTodayRecommend(item: indexPath.item)?.popupImageUrl ?? ""
     }
 }
 

--- a/Popcorn-iOS/Source/Presentation/MainScene/ViewModel/MainSceneViewModel.swift
+++ b/Popcorn-iOS/Source/Presentation/MainScene/ViewModel/MainSceneViewModel.swift
@@ -154,7 +154,7 @@ struct PopupPreviewViewData {
     let popupPeriod: String?
     let popupDDay: String?
     let popupLocation: String?
-    
+
     static let placeholder = PopupPreviewViewData(
         from: PopupPreview(
             popupId: -1,
@@ -165,14 +165,14 @@ struct PopupPreviewViewData {
             popupLocation: "팝콘시 팝콘구 팝콘로 0번길"
         )
     )
-    
+
     init(from popupPreview: PopupPreview) {
         self.popupId = popupPreview.popupId
         self.popupImageUrl = popupPreview.popupImageUrl
         self.popupTitle = popupPreview.popupTitle
         self.popupLocation = popupPreview.popupLocation
         self.popupDDay = "D-\(PopupDateFormatter.calculateDDay(from: popupPreview.popupEndDate))"
-        
+
         self.popupPeriod = popupPreview.popupStartDate.map { startDate in
             let startDateString = PopupDateFormatter.formattedPopupStoreDate(from: startDate)
             let endDateString = PopupDateFormatter.formattedPopupStoreDate(from: popupPreview.popupEndDate)

--- a/Popcorn-iOS/Source/Presentation/MainScene/ViewModel/MainSceneViewModel.swift
+++ b/Popcorn-iOS/Source/Presentation/MainScene/ViewModel/MainSceneViewModel.swift
@@ -127,7 +127,7 @@ extension MainSceneViewModel {
 
     func getTodayRecommendPopupId(at index: Int) -> Int {
         // TODO: - -1 반환 대신 nil 리턴, detailViewController 생성자에서 popupId가 nil일 때 처리.
-        return mainSceneDataSource.getTodayRecommend(item: index)?.popupId ?? -1
+        return mainSceneDataSource.getTodayRecommend(item: index)?.id ?? -1
     }
 
     func getInterestCategoryTitle(for section: MainSceneSection) -> String {
@@ -142,7 +142,7 @@ extension MainSceneViewModel {
     }
 
     func provideCarouselImageUrl(at indexPath: IndexPath) -> String {
-        return mainSceneDataSource.getTodayRecommend(item: indexPath.item)?.popupImageUrl ?? ""
+        return mainSceneDataSource.getTodayRecommend(item: indexPath.item)?.imageUrl ?? ""
     }
 }
 
@@ -167,15 +167,15 @@ struct PopupPreviewViewData {
     )
 
     init(from popupPreview: PopupPreview) {
-        self.popupId = popupPreview.popupId
-        self.popupImageUrl = popupPreview.popupImageUrl
-        self.popupTitle = popupPreview.popupTitle
-        self.popupLocation = popupPreview.popupLocation
-        self.popupDDay = "D-\(PopupDateFormatter.calculateDDay(from: popupPreview.popupEndDate))"
+        self.popupId = popupPreview.id
+        self.popupImageUrl = popupPreview.imageUrl
+        self.popupTitle = popupPreview.title
+        self.popupLocation = popupPreview.location
+        self.popupDDay = "D-\(PopupDateFormatter.calculateDDay(from: popupPreview.endDate))"
 
-        self.popupPeriod = popupPreview.popupStartDate.map { startDate in
+        self.popupPeriod = popupPreview.startDate.map { startDate in
             let startDateString = PopupDateFormatter.formattedPopupStoreDate(from: startDate)
-            let endDateString = PopupDateFormatter.formattedPopupStoreDate(from: popupPreview.popupEndDate)
+            let endDateString = PopupDateFormatter.formattedPopupStoreDate(from: popupPreview.endDate)
             return "\(startDateString)~\(endDateString)"
         }
     }

--- a/Popcorn-iOS/Source/Presentation/MainScene/ViewModel/MainSceneViewModel.swift
+++ b/Popcorn-iOS/Source/Presentation/MainScene/ViewModel/MainSceneViewModel.swift
@@ -7,11 +7,19 @@
 
 import Foundation
 
+enum MainSceneSection: Equatable {
+    case userPick
+    case userInterest(index: Int)
+    case closingSoon
+}
+
 final class MainSceneViewModel: MainCarouselViewModelProtocol {
     private let popupFetchListUseCase: PopupFetchListUseCaseProtocol
     private let imageFetchUseCase: ImageFetchUseCaseProtocol
     private let mainSceneDataSource: MainSceneDataSource
 
+    /// 오늘의 추천, 찜 목록, 관심사, 지금 놓치면 안될 팝업 섹션들 중 현재 화면에 표시될 섹션을 담는 배열
+    private(set) var sections = [MainSceneSection]()
     private var hasNextPage = true
     private var page = 1
 
@@ -33,6 +41,25 @@ final class MainSceneViewModel: MainCarouselViewModelProtocol {
     func getDataSource() -> MainSceneDataSource {
         return mainSceneDataSource
     }
+
+    private func updateSections() {
+        sections = buildSections()
+    }
+
+    private func buildSections() -> [MainSceneSection] {
+        var sections = [MainSceneSection]()
+        
+        if mainSceneDataSource.numbersOfPopup(of: .userPick) > 0 {
+            sections.append(.userPick)
+        }
+
+        let interestCount = mainSceneDataSource.numbersOfInterest()
+        sections += (0..<interestCount).map { .userInterest(index: $0) }
+
+        sections.append(.closingSoon)
+        
+        return sections
+    }
 }
 
 // MARK: - Networking
@@ -53,6 +80,7 @@ extension MainSceneViewModel {
                 let popupMainList = response.data
                 self.hasNextPage = response.hasNextPage
                 self.mainSceneDataSource.updateData(popupMainList)
+                self.updateSections()
                 fetchPopupDataPublisher?()
             case .failure(let error):
                 print(error)

--- a/Popcorn-iOS/Source/Presentation/MainScene/ViewModel/MainSceneViewModel.swift
+++ b/Popcorn-iOS/Source/Presentation/MainScene/ViewModel/MainSceneViewModel.swift
@@ -154,7 +154,7 @@ struct PopupPreviewViewData {
     let popupPeriod: String?
     let popupDDay: String?
     let popupLocation: String?
-
+    
     static let placeholder = PopupPreviewViewData(
         from: PopupPreview(
             popupId: -1,
@@ -165,14 +165,14 @@ struct PopupPreviewViewData {
             popupLocation: "팝콘시 팝콘구 팝콘로 0번길"
         )
     )
-
+    
     init(from popupPreview: PopupPreview) {
         self.popupId = popupPreview.popupId
         self.popupImageUrl = popupPreview.popupImageUrl
         self.popupTitle = popupPreview.popupTitle
         self.popupLocation = popupPreview.popupLocation
         self.popupDDay = "D-\(PopupDateFormatter.calculateDDay(from: popupPreview.popupEndDate))"
-
+        
         self.popupPeriod = popupPreview.popupStartDate.map { startDate in
             let startDateString = PopupDateFormatter.formattedPopupStoreDate(from: startDate)
             let endDateString = PopupDateFormatter.formattedPopupStoreDate(from: popupPreview.popupEndDate)

--- a/Popcorn-iOS/Source/Presentation/MainScene/ViewModel/MainSceneViewModel.swift
+++ b/Popcorn-iOS/Source/Presentation/MainScene/ViewModel/MainSceneViewModel.swift
@@ -91,7 +91,7 @@ extension MainSceneViewModel {
     }
 
     func provideCarouselImageUrl(at indexPath: IndexPath) -> String {
-        return mainSceneDataSource.item(at: indexPath).popupImageUrl
+        return mainSceneDataSource.getCarouselImageUrl(at: indexPath)
     }
 }
 

--- a/Popcorn-iOS/Source/Presentation/MainScene/ViewModel/PopupDetailViewModel.swift
+++ b/Popcorn-iOS/Source/Presentation/MainScene/ViewModel/PopupDetailViewModel.swift
@@ -132,9 +132,9 @@ struct PopupMainInformationViewData {
 
     static let placeholder = PopupMainInformationViewData(
         from: PopupInformation(
-            popupId: -1,
-            popupImagesUrl: [],
-            popupTitle: "팝콘 팝업스토어",
+            id: -1,
+            imageUrls: [],
+            title: "팝콘 팝업스토어",
             startDate: DateFormatter.apiDateFormatter.date(from: "1900-01-01 00:00:00")!,
             endDate: DateFormatter.apiDateFormatter.date(from: "1900-01-01 00:00:00")!,
             isPick: false,
@@ -151,9 +151,9 @@ struct PopupMainInformationViewData {
         let startDateString = PopupDateFormatter.formattedPopupStoreDate(from: entity.startDate)
         let endDateString = PopupDateFormatter.formattedPopupStoreDate(from: entity.endDate)
 
-        self.popupId = entity.popupId
-        self.popupImagesUrl = entity.popupImagesUrl
-        self.popupTitle = entity.popupTitle
+        self.popupId = entity.id
+        self.popupImagesUrl = entity.imageUrls
+        self.popupTitle = entity.title
         self.popupPeriod = "\(startDateString)~\(endDateString)"
         self.isPick = entity.isPick
         self.hashTags = entity.hashTags
@@ -171,9 +171,9 @@ struct PopupDetailInformationViewData {
 
     static let placeholder = PopupDetailInformationViewData(
         from: PopupInformation(
-            popupId: -1,
-            popupImagesUrl: [],
-            popupTitle: "팝콘 팝업스토어",
+            id: -1,
+            imageUrls: [],
+            title: "팝콘 팝업스토어",
             startDate: DateFormatter.apiDateFormatter.date(from: "1900-01-01 00:00:00")!,
             endDate: DateFormatter.apiDateFormatter.date(from: "1900-01-01 00:00:00")!,
             isPick: false,
@@ -230,10 +230,10 @@ struct PopupReviewViewData {
         from: PopupReview(
             profileImageUrl: nil,
             nickName: "팝콘이",
-            reviewRating: 0,
-            reviewDate: DateFormatter.apiDateFormatter.date(from: "1900-01-01 00:00:00")!,
-            reviewImagesUrl: nil,
-            reviewText: "",
+            rating: 0,
+            createdAt: DateFormatter.apiDateFormatter.date(from: "1900-01-01 00:00:00")!,
+            reviewImageUrls: nil,
+            content: "",
             likeCount: 0,
             isLiked: false
         )
@@ -242,10 +242,10 @@ struct PopupReviewViewData {
     init(from entity: PopupReview) {
         self.profileImageUrl = entity.profileImageUrl
         self.nickname = entity.nickName
-        self.reviewRating = entity.reviewRating
-        self.reviewDate = PopupDateFormatter.formattedReviewDate(from: entity.reviewDate)
-        self.reviewImagesUrl = entity.reviewImagesUrl
-        self.reviewText = entity.reviewText
+        self.reviewRating = entity.rating
+        self.reviewDate = PopupDateFormatter.formattedReviewDate(from: entity.createdAt)
+        self.reviewImagesUrl = entity.reviewImageUrls
+        self.reviewText = entity.content
         self.likeCount = String(entity.likeCount)
         self.isLiked = entity.isLiked
     }

--- a/Popcorn-iOS/Source/Presentation/MainScene/ViewModel/PopupOverviewViewModel.swift
+++ b/Popcorn-iOS/Source/Presentation/MainScene/ViewModel/PopupOverviewViewModel.swift
@@ -99,9 +99,9 @@ struct PopupOverviewViewData {
 
     static let placeHolder = PopupOverviewViewData(
         from: PopupOverview(
-            popupId: -1,
-            popupImageUrl: "",
-            popupTitle: "팝콘팝업스토어",
+            id: -1,
+            imageUrl: "",
+            title: "팝콘팝업스토어",
             startDate: Date(),
             endDate: Date(),
             address: "팝콘시 팝콘구 팝콘로 0번길"
@@ -112,9 +112,9 @@ struct PopupOverviewViewData {
         let startDate = PopupDateFormatter.formattedPopupStoreDate(from: entity.startDate)
         let endDate = PopupDateFormatter.formattedPopupStoreDate(from: entity.endDate)
 
-        popupId = entity.popupId
-        popupImageUrl = entity.popupImageUrl
-        popupTitle = entity.popupTitle
+        popupId = entity.id
+        popupImageUrl = entity.imageUrl
+        popupTitle = entity.title
         popupPeriod = startDate + "~" + endDate
         popupAddress = entity.address
     }

--- a/Popcorn-iOSTests/MainScene/DetailSceneUseCaseTests.swift
+++ b/Popcorn-iOSTests/MainScene/DetailSceneUseCaseTests.swift
@@ -27,9 +27,9 @@ final class DetailSceneUseCaseTests: XCTestCase {
     func test_해시태그가_정상적으로_추출되는지() {
         // Given
         let popupInfo1 = PopupInformation(
-            popupId: -1,
-            popupImagesUrl: [""],
-            popupTitle: "",
+            id: -1,
+            imageUrls: [""],
+            title: "",
             startDate: Date(),
             endDate: Calendar.current.date(byAdding: .day, value: 10, to: Date())!,
             isPick: true,
@@ -42,9 +42,9 @@ final class DetailSceneUseCaseTests: XCTestCase {
         )
         
         let popupInfo2 = PopupInformation(
-            popupId: -1,
-            popupImagesUrl: [""],
-            popupTitle: "",
+            id: -1,
+            imageUrls: [""],
+            title: "",
             startDate: Date(),
             endDate: Calendar.current.date(byAdding: .day, value: 5, to: Date())!,
             isPick: true,
@@ -55,11 +55,10 @@ final class DetailSceneUseCaseTests: XCTestCase {
             introduce: "",
             reservationUrl: ""
         )
-        
         let popupInfo3 = PopupInformation(
-            popupId: -1,
-            popupImagesUrl: [""],
-            popupTitle: "",
+            id: -1,
+            imageUrls: [""],
+            title: "",
             startDate: Date(),
             endDate: Calendar.current.date(byAdding: .day, value: -5, to: Date())!,
             isPick: true,


### PR DESCRIPTION
# 배경
기존 메인화면의 코드들에는 다음과 같은 문제점들이 있었습니다.
- 중복된 로직 다수 존재
- 비슷한 기능을 하는 메서드 다수 존재
- 코드가 너무 길고 복잡해 기능 추가 또는 유지 보수 시 어려움이 존재했고 에러 대응이 힘듦.
- 뷰와 뷰 모델의 책임 분리가 모호
따라서 중복된 코드들을 제거하고, 로직을 개선하였습니다.

# 작업 내용
## 1. 오류 수정
### (1) 메인 화면 데이터 fetch 후 화면 갱신이 되지 않는 문제 해결
- 기존 코드
```swift
    func bind(to viewModel: MainSceneViewModel) {
        viewModel.fetchPopupImagesErrorPublisher = { [weak self] in
            guard let self else { return }
            self.mainCollectionView.reloadData()
        }

        viewModel.fetchPopupImagesErrorPublisher = { [weak self] in
            guard let self else { return }
            DispatchQueue.main.async {
                self.mainCollectionView.reloadData()
            }
        }
    }
```
MainSceneViewController의 bind 메서드에서 화면을 갱신하는 publisher인 `fetchPopupDataPublisher`에 바인딩하지 않고, `fetchPopupImagesErrorPublisher`에 두 번 바인딩 했습니다. ~~저는 바보입니다.~~

따라서 원래 의도대로 `fetchPopupDataPublisher`에 바인딩을 하고, 메인 스레드에서 `reloadData()`를 호출하도록 변경했습니다.
- 수정된 코드
```swift
    func bind(to viewModel: MainSceneViewModel) {
        viewModel.fetchPopupDataPublisher = { [weak self] in
            guard let self else { return }
            DispatchQueue.main.async {
                self.mainCollectionView.reloadData()
            }
        }

        viewModel.fetchPopupImagesErrorPublisher = { [weak self] in
            guard let self else { return }
            DispatchQueue.main.async {
                self.mainCollectionView.reloadData()
            }
        }
    }
```
### (2) 메인화면에서 캐러셀 이미지를 잘못 불러오던 오류 해결
MainSceneViewModel의 `provideCarouselImageUrl` 메서드에서 `mainSceneDataSource.item()`를 호출하여 캐러셀 이미지 url을 받아왔습니다.  
그러나 해당 메서드는 오늘의 추천 팝업(캐러셀 이미지) 데이터를 반환하는 메서드가 아니라, 찜 목록, 관심사, 지금 놓치면 안 될 팝업스토어의 데이터를 반환하는 함수입니다. ~~저는 바보입니다.~~  
따라서 `MainSceneDataSource`에 캐러셀 이미지를 반환하는 `getCarouselImageUrl()` 메서드를 추가하여 해결했습니다.

## 2. MainSceneSection 열거형 도입
### (1) 도입 이유
기존에는 섹션 번호(`indexPath.section`)를 기반으로 직접 분기하여 데이터를 처리하고 있었기 때문에 각 섹션이 어떤 역할을 하는지 명확히 표현하기 어려웠습니다.  
따라서 **찜 목록**, **관심사**, **지금 놓치면 안 될 팝업스토어** 섹션을 명시적으로 표현할 수 있는 `MainSceneSection` 열거형을 도입하였습니다.

아래와 같이 도메인 모델에 `PopupSectionCategory`라는 열거형이 있습니다.
```swift
enum PopupSectionCategory {
    case todayRecommend
    case userPick
    case userInterest(InterestCategory?)
    case closingSoon
}
```
이 열거형을 사용할까 고민했지만, 현재 구조에서는 `userInterest`의 연관값으로 인덱스가 들어가는 것이 컬렉션 뷰 데이터 소스 로직 처리에 편리하기에 프레젠테이션 모델 느낌으로 새로 추가했습니다.  

또한 `MainSceneSection`에는 `todayRecommend`가 필요없기에 현재 구조에서는 분리하는게 적절하다고 판단했습니다.

### (2) 변경된 부분
#### 1) sections 배열과 buildSections, updateSections
sections 배열은 오늘의 추천, 찜 목록, 관심사, 지금 놓치면 안될 팝업 섹션들 중 **현재 화면에 표시될 섹션들**을 담는 상태 변수입니다.  
뷰 모델에서 네트워킹 작업(`fetchPopupList()`) 이후 섹션 상태를 갱신할 수 있도록 `updateSections()`메서드를 호출합니다.

이 과정에서 책임이 분리된 구조로 설계하였습니다.
- 섹션 계산: `buildSections()`
- 상태 변경: `updateSections()`
- 네트워킹: `fetchPopupList()`

- `buildSections()`는 순수하게 섹션 구성을 계산만 하므로 테스트가 용이합니다.
- `updateSections()`는 상태를 변경하는 책임만 가집니다.
- `fetchPopupList()`는 데이터 fetch 이후 `updateSections()` 메서드에 상태 변경을 위임합니다.

또한 `MainSceneViewController`에서는 `sections`라는 상태 변수를 유일하게 신뢰하게 되므로, MVVM의 "뷰는 뷰모델의 상태만 바라봐야 한다"는 원칙에 부합하도록 설계하였습니다.

## 3. MainSceneDataSource 구조 개선
`MainSceneDataSource`가 원래의 역할인 **데이터를 저장하는 역할**보다 더 많은 역할을 하게 되었습니다.  
도메인 모델을 받아 뷰모델로 변경하는 역할을 하고 있었기에 코드가 복잡해졌었습니다.  

따라서 `MainSceneDataSource`는 도메인 모델 타입으로 데이터를 저장하도록 하고, **데이터를 저장**만 하도록 구조를 변경했습니다.

이에 따라 `MainSceneViewModel`이 도메인 모델에서 뷰 모델로 가공하도록 하고, 뷰에게 데이터를 전달하는 역할도 수행하도록 변경했습니다.  

기존에는 뷰 컨트롤러에서 `MainSceneViewModel.getDataSource()`를 호출하여 뷰 컨트롤러가 데이터 소스에 직접 접근해 데이터를 받아왔습니다.  
이 구조에서는 뷰 컨트롤러는 `MainSceneViewModel`도 알아야하고, `MainSceneDataSource`도 알아야하기 때문에 의존성을 줄일 필요가 있었습니다.  
따라서 뷰 컨트롤러가 데이터 소스에 접근하기 위해서는 `MainSceneViewModel`에 접근해 `MainSceneDataSource`에 간접 접근하도록 구조를 변경했습니다.  
이를 통해 뷰 컨트롤러는 `MainSceneDataSource`의 구현과 관계없이 데이터를 받아올 수 있게 되었습니다.

## 3. UICollectionView DataSource 메서드 로직 개선
`MainSceneViewController`의 `UICollectionView DataSource` 메서드들은 중복된 코드도 많고, 길고 매우 복잡했습니다.  
이를 개선하기 위해 다음의 작업을 진행했습니다.
>
- 중복된 이미지 로딩 로직을 `PopupPreviewViewData`의 `convertToImage` 메서드를 추가해 개선
- 셀의 데이터 구성(configureData) 책임을 뷰 컨트롤러가 아닌 셀에게 위임
- `PickOrInterestCell`과 `ClosingSoonPopupCell`의 공통 기능인 `configureContents`를 추상화하는 프로토콜을 정의해 `cellForItemAt` 메서드 간소화

### (1) 중복된 이미지 로딩 로직 개선
기존에는 `configurePickOrInterestCell`, `configureClosingSoonPopupCell` 등 여러 셀 구성 메서드에 이미지 로딩 로직이 중복되어 존재했습니다.  
따라서 각각의 메서드마다 fetchImage → Result 처리 → 이미지 fallback → main thread 업데이트 로직이 반복되어 가독성과 유지보수성 저하되었습니다.

이를 해결하기 위해
`PopupPreviewViewData에` `convertToImage(from:)` 메서드를 추가하여 이미지 처리 로직을 ViewModelData 객체로 이동시켰습니다.  
`ViewController에서는` `fetchImage` 호출 후 `convertToImage만` 사용하도록 하여 책임을 분리하고 로직을 간결하게 했습니다.  

`convertToImage` 메서드는 이미지 fetch의 `result: <Data, ImageFetchError>`를 파라미터로 받아 내부에서 성공, 실패를 처리합니다.

`PopupPreviewViewData`의 익스텐션을 `MainSceneViewController`에서 선언한 이유는 다음과 같습니다.  
UIImage를 반환하기 위해 UIKit이 필요 -> `PopupPreviewViewData`가 선언된 `MainSceneViewModel`에서 선언하면 뷰 모델이 UI 프레임워크에 의존하게 됨.  
-> 따라서 뷰 컨트롤러 파일 내부에서 선언해 해당 메서드는 UIKit 전용임을 명시하고자.. 했습니다!

- 변경 전
```swift
     private func configurePickOrInterestCell(
        _ collectionView: UICollectionView,
        for indexPath: IndexPath,
        _ popupData: PopupPreviewViewData
    ) -> UICollectionViewCell {
        guard let cell = collectionView.dequeueReusableCell(
            withReuseIdentifier: PickOrInterestCell.reuseIdentifier,
            for: indexPath
        ) as? PickOrInterestCell else {
            return UICollectionViewCell()
        }

        if let popupDDay = popupData.popupDDay {
            mainViewModel.fetchImage(url: popupData.popupImageUrl) { result in
                switch result {
                case .success(let imageData):
                    let image = UIImage(data: imageData) ?? UIImage(resource: .popupPreviewPlaceHolder)
                    DispatchQueue.main.async {
                        cell.configureContents(
                            popupImage: image,
                            popupTitle: popupData.popupTitle,
                            dDay: popupDDay
                        )
                    }
                case .failure:
                    DispatchQueue.main.async {
                        cell.configureContents(
                            popupImage: UIImage(resource: .popupPreviewPlaceHolder),
                            popupTitle: popupData.popupTitle,
                            dDay: popupDDay
                        )
                    }
                }
            }
        } else {
            cell.configureContents(
                popupImage: UIImage(resource: .popupPreviewPlaceHolder),
                popupTitle: PopupPreviewViewData.placeholder.popupTitle,
                dDay: PopupPreviewViewData.placeholder.popupDDay!
            )
        }

        return cell
    }
```

- 변경 후
```swift
// MainSceneViewController.swift
    private func configurePickOrInterestCell(
        _ collectionView: UICollectionView,
        for indexPath: IndexPath,
        _ popupData: PopupPreviewViewData
    ) -> UICollectionViewCell {
        guard let cell = collectionView.dequeueReusableCell(
            withReuseIdentifier: PickOrInterestCell.reuseIdentifier,
            for: indexPath
        ) as? PickOrInterestCell else {
            return UICollectionViewCell()
        }

        mainViewModel.fetchImage(url: popupData.popupImageUrl) { result in
            let image = popupData.convertToImage(from: result)
            DispatchQueue.main.async {
                cell.configureContents(with: popupData, image: image)
            }
        }

        return cell
    }


// MARK: - Extensions
extension PopupPreviewViewData {
    func convertToImage(from result: Result<Data, ImageFetchError>) -> UIImage {
        switch result {
        case .success(let data):
            return UIImage(data: data) ?? UIImage(resource: .popupPreviewPlaceHolder)
        case .failure(let error):
            print("팝업 프리뷰 이미지 로딩 실패: \(error.localizedDescription)")
            return UIImage(resource: .popupPreviewPlaceHolder)
        }
    }
}
```

### (2) `PickOrInterestCell`과 `ClosingSoonPopupCell`의 공통 기능인 `configureContents`를 추상화하는 프로토콜을 정의해 `cellForItemAt` 메서드 간소화
`cellForItemAt`에서 섹션에 따라 `PickOrInterestCell` 또는 `ClosingSoonPopupCell` 셀을 구성했습니다.  
이를 위해 switch 문으로 분기하였고, 중복된 코드가 많아 코드 길이를 늘린 주범이었습니다.  

따라서 셀 구성 메서드인 `configureContents`를 추상화한 프로토콜인 `ConfigurablePopupPreviewCell` 프로토콜을 정의해 `PickOrInterestCell`과 `ClosingSoonPopupCell`에서 채택했습니다.

뷰 컨트롤러에서는 `configure` 메서드에 `popupData`와 로딩한 이미지를 넘겨주고, 각 셀에서 필요한 데이터를 꺼내 구성하도록 변경했습니다.  

`refactor: cellForItemAt 메서드 간소화` - `8993fc2` 커밋에서 코드가 엄청 줄었음을 확인하실 수 있습니다!!

## 4. 모델 필드 이름 변경
타입 이름과 필드 이름에 중복이 있었습니다.  
프레젠테이션 레이어는 아니지만, 생각난김에 이름을 간소화했습니다!
```
ex) PopupPreview.popupId -> PopupPreview.id
```

# 테스트 방법 및 리뷰 노트
리팩토링 할게 몇 개 더 남았습니다..ㅠ 대규모 공사라 여기저기 많이 건드려서 아직 화면이 정상 동작하지는 않아 테스트는 불가능합니다ㅠㅠ  
다음 리팩토링은 아마 캐러셀 뷰 구조 변경일 것 같은데 이번 주 내로 끝내보겠습니다!
