### PR TITLE
[Refactor] completion 기반의 네트워킹 메서드를 Swift Concurrency로 마이그레이션합니다.

### DIFF
--- a/Popcorn-iOS/Source/Data/DTO/DefaultResponseDTO.swift
+++ b/Popcorn-iOS/Source/Data/DTO/DefaultResponseDTO.swift
@@ -5,8 +5,8 @@
 //  Created by 제민우 on 2/26/25.
 //
 
-struct DefaultResponseDTO: Decodable {
+struct DefaultResponseDTO<T: Decodable>: Decodable {
     let resultCode: Int
     let status: String
-    let data: String
+    let data: T
 }

--- a/Popcorn-iOS/Source/Data/Network/NetworkManager/NetworkError.swift
+++ b/Popcorn-iOS/Source/Data/Network/NetworkManager/NetworkError.swift
@@ -7,39 +7,86 @@
 
 import Foundation
 
-enum NetworkError: Error {
-    case invalidURL                       // 유효하지 않은 URL
-    case responseError                    // 유효하지 않은 응답값일 경우
-    case decodingError(Error)             // 데이터 파싱 실패
-    case emptyData                        // 응답 데이터가 비어있는 경우
-    case serverError(ServerError)         // 서버 에러
-    case requestFailed(String)            // 서버 요청 실패한 경우
-    case unknown                          // 알 수 없는 오류
+/// 네트워크 요청 과정에서 발생할 수 있는 모든 에러를 정의합니다.
+/// - 요청 생성, 전송, 응답 수신, 디코딩, 서버 오류 응답까지 전 과정을 다룹니다.
+enum NetworkError: Error, CustomStringConvertible {
+    /// 유효하지 않은 URL 문자열로 인해 URL 생성에 실패한 경우
+    case invalidURL
+
+    /// URLSession 네트워크 요청 자체가 실패한 경우 (인터넷 끊김, 타임아웃 등)
+    case urlSessionFailed(Error)
+
+    /// response가 HTTPURLResponse로 다운 캐스팅 실패한 경우
+    case invalidResponse
+
+    /// 서버가 실패 응답을 반환한 경우 (4xx 또는 5xx)
+    /// - code: HTTP 상태 코드
+    /// - message: 서버가 전달한 에러 메시지 (Optional)
+    case serverError(code: ServerErrorCode, message: String? = nil)
+
+    /// 응답 데이터가 없거나 nil인 경우
+    case emptyData
+
+    /// 요청 바디 인코딩(JSON 등)이 실패한 경우
+    case encodingFailed(Error)
+
+    /// 응답 데이터를 디코딩(파싱)하는 데 실패한 경우
+    case decodingFailed(Error)
+
+    /// 위에서 명시되지 않은 알 수 없는 에러 (디버깅용)
+    case unknown(Error? = nil)
 
     var description: String {
         switch self {
         case .invalidURL:
-            "URL이 올바르지 않습니다."
-        case .responseError:
-            "응답값이 유효하지 않습니다."
-        case .decodingError(let error):
-            "디코딩 에러: \(error.localizedDescription)"
+            return "invalidURL) 예시: URLComponents(string: baseURL) 생성 실패."
+        case .urlSessionFailed(let error):
+            return "urlSessionFailed) 네트워크 요청 중 URLSession 에러 발생: \(error.localizedDescription)"
+        case .invalidResponse:
+            return "invalidResponse) 응답 객체가 HTTPURLResponse 형식이 아님. 유효한 HTTP 응답이 아님."
+        case let .serverError(code, message):
+            return "serverError) 상태 코드: \(code.description), 서버 메시지: \(message ?? "없음")"
         case .emptyData:
-            "데이터가 없습니다."
-        case .serverError(let error):
-            "서버 에러 \(error.rawValue): \(error)"
-        case .requestFailed(let message):
-            "서버 요청 실패 \(message)"
-        case .unknown:
-            "알 수 없는 에러"
+            return "emptyData) 응답은 정상적으로 도착했으나, 데이터가 비어 있거나 존재하지 않음."
+        case .encodingFailed(let error):
+            return "encodingFailed) 요청 바디 인코딩(JSON 변환 등)에 실패: \(error.localizedDescription)"
+        case .decodingFailed(let error):
+            return "decodingFailed) 응답 데이터를 디코딩(파싱) 실패: \(error.localizedDescription)"
+        case .unknown(let error):
+            return "unknown) 알 수 없는 오류가 발생: \(error?.localizedDescription ?? "정보 없음")"
         }
     }
 }
 
-enum ServerError: Int {
-    case unknown = -1           // 알 수 없는 오류
-    case badRequest = 400       // 잘못된 요청
-    case unauthorized = 401     // 인증 실패
-    case forbidden = 403        // 접근 권한 없음
-    case notFound = 404         // 요청한 리소스를 찾을 수 없음
+enum ServerErrorCode: Int {
+    /// 알 수 없는 서버 오류 (명시되지 않은 상태 코드 대응용)
+    case unknown = -1
+
+    /// 클라이언트의 요청이 잘못되어 서버가 처리할 수 없음 (ex. 필드 누락, 파라미터 오류 등)
+    case badRequest = 400
+
+    /// 인증 실패 (ex. 토큰 없음, 만료, 잘못된 자격 증명 등)
+    case unauthorized = 401
+
+    /// 인증은 되었지만, 해당 리소스에 접근할 권한이 없음
+    case forbidden = 403
+
+    /// 요청한 리소스를 서버에서 찾을 수 없음
+    case notFound = 404
+
+    var description: String {
+        let code = self.rawValue
+        switch self {
+        case .badRequest:
+            return "\(code) Bad Request: 클라이언트 요청이 잘못되어 서버가 처리할 수 없습니다."
+        case .unauthorized:
+            return "\(code) Unauthorized: 인증 정보가 없거나 유효하지 않습니다."
+        case .forbidden:
+            return "\(code) Forbidden: 서버가 요청을 이해했지만 권한이 없어 거부되었습니다."
+        case .notFound:
+            return "\(code) Not Found: 요청한 리소스를 서버에서 찾을 수 없습니다."
+        case .unknown:
+            return "Unknown: 정의되지 않은 서버 오류입니다."
+        }
+    }
 }

--- a/Popcorn-iOS/Source/Data/Network/NetworkManager/NetworkManager.swift
+++ b/Popcorn-iOS/Source/Data/Network/NetworkManager/NetworkManager.swift
@@ -19,25 +19,10 @@ extension NetworkManagerProtocol {
     func request<Request: Requestable>(
         endpoint: Request
     ) async throws -> Request.Response {
-        guard let request = endpoint.makeURLRequest() else {
-            throw NetworkError.invalidURL
-        }
-
+        guard let request = endpoint.makeURLRequest() else { throw NetworkError.invalidURL }
         let (data, response) = try await URLSession.shared.data(for: request)
-
-        guard let httpResponse = response as? HTTPURLResponse else {
-            throw NetworkError.responseError
-        }
-
-        guard (200..<300) ~= httpResponse.statusCode else {
-            if let serverError = ServerError(rawValue: httpResponse.statusCode) {
-                throw NetworkError.serverError(serverError)
-            } else {
-                throw NetworkError.unknown
-            }
-        }
-
-        return try JSONDecoder().decode(Request.Response.self, from: data)
+        try validate(data: data, response: response)
+        return try decode(Request.Response.self, from: data)
     }
 
     func upload<Request: JSONBodyRequestable>(
@@ -45,20 +30,33 @@ extension NetworkManagerProtocol {
     ) async throws -> Request.Response {
         let (request, body) = try endpoint.makeURLRequest()
         let (data, response) = try await URLSession.shared.upload(for: request, from: body)
-        
+        try validate(data: data, response: response)
+        return try decode(Request.Response.self, from: data)
+    }
+}
+
+extension NetworkManagerProtocol {
+    private func validate(data: Data, response: URLResponse) throws {
         guard let httpResponse = response as? HTTPURLResponse else {
             throw NetworkError.responseError
         }
-        
+
         guard (200..<300) ~= httpResponse.statusCode else {
-            if let serverError = ServerError(rawValue: httpResponse.statusCode) {
-                throw NetworkError.serverError(serverError)
-            } else {
-                throw NetworkError.unknown
-            }
+            let serverError: ServerError = .init(rawValue: httpResponse.statusCode) ?? .unknown
+            throw NetworkError.serverError(serverError)
         }
 
-        return try JSONDecoder().decode(Request.Response.self, from: data)
+        guard !data.isEmpty else {
+            throw NetworkError.emptyData
+        }
+    }
+
+    private func decode<T: Decodable>(_ type: T.Type, from data: Data) throws -> T {
+        do {
+            return try JSONDecoder().decode(T.self, from: data)
+        } catch {
+            throw NetworkError.decodingError(error)
+        }
     }
 }
 
@@ -118,14 +116,6 @@ final class NetworkManager: NetworkManagerProtocol {
                 completion(.failure(NetworkError.decodingError(error)))
             }
         }
-
-//        let task: Cancellable
-//
-//        if let body = request.httpBody {
-//            task = session.uploadTask(with: request, from: body, completionHandler: completionHandler)
-//        } else {
-//            task = session.dataTask(with: request, completionHandler: completionHandler)
-//        }
 
         let task = session.dataTask(with: request, completionHandler: completionHandler)
         task.resume()

--- a/Popcorn-iOS/Source/Data/Network/NetworkManager/NetworkManager.swift
+++ b/Popcorn-iOS/Source/Data/Network/NetworkManager/NetworkManager.swift
@@ -38,14 +38,13 @@ extension NetworkManagerProtocol {
 extension NetworkManagerProtocol {
     private func validate(data: Data, response: URLResponse) throws {
         guard let httpResponse = response as? HTTPURLResponse else {
-            throw NetworkError.responseError
+            throw NetworkError.invalidResponse
         }
 
         guard (200..<300) ~= httpResponse.statusCode else {
-            let serverError: ServerError = .init(rawValue: httpResponse.statusCode) ?? .unknown
-            // 네트워크 에러 수정 후 사용 예정
+            let serverErrorCode: ServerErrorCode = .init(rawValue: httpResponse.statusCode) ?? .unknown
             let errorMessage = try? decode(DefaultResponseDTO<String>.self, from: data).data
-            throw NetworkError.serverError(serverError)
+            throw NetworkError.serverError(code: serverErrorCode, message: errorMessage)
         }
 
         guard !data.isEmpty else {
@@ -57,7 +56,7 @@ extension NetworkManagerProtocol {
         do {
             return try JSONDecoder().decode(T.self, from: data)
         } catch {
-            throw NetworkError.decodingError(error)
+            throw NetworkError.decodingFailed(error)
         }
     }
 }
@@ -83,20 +82,20 @@ final class NetworkManager: NetworkManagerProtocol {
 
         let completionHandler: (Data?, URLResponse?, Error?) -> Void = { data, response, error in
             if let error {
-                completion(.failure(NetworkError.requestFailed(error.localizedDescription)))
+                completion(.failure(NetworkError.urlSessionFailed(error)))
                 return
             }
 
             guard let httpResponse = response as? HTTPURLResponse else {
-                completion(.failure(NetworkError.responseError))
+                completion(.failure(NetworkError.invalidResponse))
                 return
             }
 
             guard (200..<400) ~= httpResponse.statusCode else {
-                if let serverError = ServerError(rawValue: httpResponse.statusCode) {
-                    completion(.failure(NetworkError.serverError(serverError)))
+                if let serverErrorCode = ServerErrorCode(rawValue: httpResponse.statusCode) {
+                    completion(.failure(NetworkError.serverError(code: serverErrorCode)))
                 } else {
-                    completion(.failure(NetworkError.unknown))
+                    completion(.failure(NetworkError.unknown()))
                 }
                 return
             }
@@ -115,7 +114,7 @@ final class NetworkManager: NetworkManagerProtocol {
                 let decodedData: Request.Response = try JSONDecoder().decode(Request.Response.self, from: data)
                 completion(.success(decodedData))
             } catch {
-                completion(.failure(NetworkError.decodingError(error)))
+                completion(.failure(NetworkError.decodingFailed(error)))
             }
         }
 

--- a/Popcorn-iOS/Source/Data/Network/NetworkManager/NetworkManager.swift
+++ b/Popcorn-iOS/Source/Data/Network/NetworkManager/NetworkManager.swift
@@ -15,6 +15,32 @@ protocol NetworkManagerProtocol {
     ) -> Cancellable?
 }
 
+extension NetworkManagerProtocol {
+    func request<Request: Requestable>(
+        endpoint: Request
+    ) async throws -> Request.Response {
+        guard let request = endpoint.makeURLRequest() else {
+            throw NetworkError.invalidURL
+        }
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw NetworkError.responseError
+        }
+
+        guard (200..<300) ~= httpResponse.statusCode else {
+            if let serverError = ServerError(rawValue: httpResponse.statusCode) {
+                throw NetworkError.serverError(serverError)
+            } else {
+                throw NetworkError.unknown
+            }
+        }
+
+        return try JSONDecoder().decode(Request.Response.self, from: data)
+    }
+}
+
 final class NetworkManager: NetworkManagerProtocol {
     private let session: URLSession
     private let decoder: JSONDecoder

--- a/Popcorn-iOS/Source/Data/Network/NetworkManager/NetworkManager.swift
+++ b/Popcorn-iOS/Source/Data/Network/NetworkManager/NetworkManager.swift
@@ -39,6 +39,27 @@ extension NetworkManagerProtocol {
 
         return try JSONDecoder().decode(Request.Response.self, from: data)
     }
+
+    func upload<Request: JSONBodyRequestable>(
+        endpoint: Request
+    ) async throws -> Request.Response {
+        let (request, body) = try endpoint.makeURLRequest()
+        let (data, response) = try await URLSession.shared.upload(for: request, from: body)
+        
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw NetworkError.responseError
+        }
+        
+        guard (200..<300) ~= httpResponse.statusCode else {
+            if let serverError = ServerError(rawValue: httpResponse.statusCode) {
+                throw NetworkError.serverError(serverError)
+            } else {
+                throw NetworkError.unknown
+            }
+        }
+
+        return try JSONDecoder().decode(Request.Response.self, from: data)
+    }
 }
 
 final class NetworkManager: NetworkManagerProtocol {

--- a/Popcorn-iOS/Source/Data/Network/NetworkManager/NetworkManager.swift
+++ b/Popcorn-iOS/Source/Data/Network/NetworkManager/NetworkManager.swift
@@ -43,6 +43,8 @@ extension NetworkManagerProtocol {
 
         guard (200..<300) ~= httpResponse.statusCode else {
             let serverError: ServerError = .init(rawValue: httpResponse.statusCode) ?? .unknown
+            // 네트워크 에러 수정 후 사용 예정
+            let errorMessage = try? decode(DefaultResponseDTO<String>.self, from: data).data
             throw NetworkError.serverError(serverError)
         }
 

--- a/Popcorn-iOS/Source/Data/Network/Request/Implementation/JSONBodyEndpoint.swift
+++ b/Popcorn-iOS/Source/Data/Network/Request/Implementation/JSONBodyEndpoint.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct JSONBodyEndpoint<R: Decodable>: Requestable {
+struct JSONBodyEndpoint<R: Decodable>: JSONBodyRequestable {
     typealias Response = R
 
     let baseURL: String

--- a/Popcorn-iOS/Source/Data/Network/Request/Interface/Requestable.swift
+++ b/Popcorn-iOS/Source/Data/Network/Request/Interface/Requestable.swift
@@ -23,7 +23,7 @@ extension Requestable {
     func makeURL() -> URL? {
         guard var components = URLComponents(string: baseURL) else { return nil }
         components.path = path
-        components.queryItems = queryItems
+        components.queryItems = queryItems.isEmpty ? nil : queryItems
 
         return components.url
     }

--- a/Popcorn-iOS/Source/Data/Network/Request/Interface/Requestable.swift
+++ b/Popcorn-iOS/Source/Data/Network/Request/Interface/Requestable.swift
@@ -28,3 +28,28 @@ extension Requestable {
         return components.url
     }
 }
+
+protocol JSONBodyRequestable: Requestable {
+    var body: Encodable { get }
+}
+
+extension JSONBodyRequestable {
+    /// NetworkManger에서 호출하는 메서드
+    /// - Returns:
+    ///     - URLRequest
+    ///     - Body Data
+    func makeURLRequest() throws -> (URLRequest, Data) {
+        guard let url = makeURL() else {
+            throw NetworkError.invalidURL
+        }
+
+        var urlRequest = URLRequest(url: url)
+        urlRequest.httpMethod = httpMethod.rawValue
+        urlRequest.allHTTPHeaderFields = headers
+        urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
+
+        let body = try JSONEncoder().encode(body)
+
+        return (urlRequest, body)
+    }
+}

--- a/Popcorn-iOS/Source/Data/Repositories/MainScene/PopupDetailRepository.swift
+++ b/Popcorn-iOS/Source/Data/Repositories/MainScene/PopupDetailRepository.swift
@@ -183,7 +183,7 @@ final class PopupDetailRepository: PopupDetailRepositoryProtocol {
             return
         }
 
-        let endpoint = Endpoint<DefaultResponseDTO>(
+        let endpoint = Endpoint<DefaultResponseDTO<Bool>>(
             httpMethod: .post,
             path: APIConstant.popupTogglePick(popupId: String(popupId)),
             headers: ["Authorization": "Bearer \(token)"]
@@ -192,11 +192,8 @@ final class PopupDetailRepository: PopupDetailRepositoryProtocol {
         networkManager.request(endpoint: endpoint) { result in
             switch result {
             case .success(let response):
-                if let isPick = Bool(response.data) {
-                    completion(.success(isPick))
-                } else {
-                    completion(.failure(NetworkError.responseError))
-                }
+                let isPick = response.data
+                completion(.success(isPick))
             case .failure(let error):
                 completion(.failure(error))
             }

--- a/Popcorn-iOS/Source/Data/Repositories/SignUp/SignUpRepository.swift
+++ b/Popcorn-iOS/Source/Data/Repositories/SignUp/SignUpRepository.swift
@@ -126,7 +126,8 @@ extension SignUpRepository {
                     completion(.failure(error))
                 }
             case .failure(let error):
-                if case .serverError(let serverError) = error, (400...499).contains(serverError.rawValue) {
+                if case let .serverError(code, _) = error,
+                   (400...499).contains(code.rawValue) {
                     completion(.success(false))
                     return
                 }


### PR DESCRIPTION
# 배경
기존의 completion 기반의 메서드들로 인해 가독성 저하, 디버깅 어려움 등의 문제가 있었습니다.  
이를 해결하고자 Swift Concurrency를 도입했습니다.

# 작업 내용
## 1. NetworkError 케이스 수정
기존의 NetworkError의 case 이름이 발생한 에러를 표현하기 모호한 부분이 있었습니다.  
예를 들어 `requestFailed` case는 네트워크 요청 실패의 원인보다 결과를 나타내므로, 에러 메시지 출력 시 정확한 원인을 파악하기 힘들었습니다.  

따라서 각 케이스가 명확한 원인을 나타내도록 수정하고, 문서 주석을 달아 Quick Help로 확인할 수 있습니다.  
또한 NetworkError가 `CustomStringConvertible`을 채택하도록 해 필요 시 `description` 프로퍼티로 에러 메시지를 출력할 수 있습니다.

## 2. 네트워크 레이어 리팩토링   
Swift Concurrency를 이용한 `request`, `upload` 메서드를 구현했습니다.   
각 메서드에서 중복되는 **응답 검증**, **디코딩** 로직은 별도 메서드로 분리했습니다.

현재 `request`, `upload` 메서드는 NetworkManagerProtocol의 Extension으로 구현되어 있습니다.  
NetworkManagerProtocol에 의존하는 레포지토리가 많기에, Swift Concurrency와 completion 방식 모두 사용할 수 있기 위함입니다.

JSONBodyRequestable 프로토콜의 익스텐션에 구현한 아래 메서드도 같은 이유입니다
```swift
makeURLRequest() throws -> (URLRequest, Data)
```

## 3. Requestable의 url 생성 메서드 수정
URLComponents.queryItems이 빈 배열일때 URLComponents의 url은 `"https://host/path?"`와 같이 url의 가장 마지막 부분에 `?`가 붙습니다.   
따라서 빈 배열이라면 nil을 할당하도록 수정해 `?`가 해당 문제를 해결했습니다.

```swift
// 변경 전
    func makeURL() -> URL? {
        guard var components = URLComponents(string: baseURL) else { return nil }
        components.path = path
        components.queryItems = queryItems

        return components.url
    }
```
```swift
// 변경 후
    func makeURL() -> URL? {
        guard var components = URLComponents(string: baseURL) else { return nil }
        components.path = path
        components.queryItems = queryItems.isEmpty ? nil : queryItems

        return components.url
    }
```
# 테스트 방법
해당 메서드를 이용해 요청 보내시면 됩니다!
